### PR TITLE
Raise the control-plane connection idle timeout default to 5m

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ Key CLI flags for control-plane mode:
 - `--process-min-workers N` / `--process-max-workers N`
 - `--process-retire-on-session-end`
 - `--worker-queue-timeout DURATION` / `--worker-idle-timeout DURATION`
-- `--idle-timeout DURATION` — connection idle timeout: a client connection with no traffic for this long is closed and its worker released to hot-idle (in control-plane mode an idle connection otherwise pins a worker forever). **Control-plane default is `60s`** (`server.DefaultControlPlaneIdleTimeout`; standalone defaults to `24h`); a negative value disables it. `server.New` applies the standalone default, so the control plane sets it explicitly before `InitMinimalServer` (which skips that defaulting).
+- `--idle-timeout DURATION` — connection idle timeout: a client connection with no traffic for this long is closed and its worker released to hot-idle (in control-plane mode an idle connection otherwise pins a worker forever). **Control-plane default is `5m`** (`server.DefaultControlPlaneIdleTimeout`; standalone defaults to `24h`); a negative value disables it. `server.New` applies the standalone default, so the control plane sets it explicitly before `InitMinimalServer` (which skips that defaulting).
 - `--memory-budget SIZE` (default 75% RAM) / `--memory-rebalance`
 - `--socket-dir /path` (process backend)
 - `--handover-drain-timeout DURATION` (default `24h` process; **remote default is `0` = unbounded** — the CP waits for active sessions for as long as it takes and the pod's k8s `terminationGracePeriodSeconds` is the only hard wall. cloudflare/tableflip FD passing applies to process/standalone single-host upgrades, not k8s pod replacement.)

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Run with config file:
 | `DUCKGRES_DISABLE_PARQUET_PREFETCHING` | Disable DuckDB Parquet prefetching for standalone/process workers and control-plane-spawned K8s workers. Boolean values use Go's accepted forms (`true`, `TRUE`, `1`, etc.). | `false` |
 | `DUCKGRES_PROCESS_ISOLATION` | Enable process isolation (`1` or `true`) | `false` |
 | `DUCKGRES_PROCESS_RETIRE_ON_SESSION_END` | Retire a process worker immediately after its last session ends instead of keeping it warm for reuse | `false` |
-| `DUCKGRES_IDLE_TIMEOUT` | Connection idle timeout (e.g., `30m`, `1h`, `-1` to disable) | `24h` |
+| `DUCKGRES_IDLE_TIMEOUT` | Connection idle timeout (e.g., `30m`, `1h`, `-1` to disable) | `24h` standalone, `5m` control-plane |
 | `DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX` | Maximum client-requested `duckgres.idle_timeout`; unset disables client overrides | disabled |
 | `DUCKGRES_SESSION_INIT_TIMEOUT` | Session startup metadata initialization and catalog probe timeout | `10s` |
 | `DUCKGRES_WORKER_QUEUE_TIMEOUT` | Max time to wait for worker acquisition and per-org/per-user vCPU resource admission; the managed K8s queue TTL uses this value | `60s` |
@@ -424,7 +424,7 @@ Run with config file:
 ### Client-requested idle timeout
 
 The control plane closes inactive client sessions after its configured
-`DUCKGRES_IDLE_TIMEOUT` (60 seconds by default). To let clients request a
+`DUCKGRES_IDLE_TIMEOUT` (5 minutes by default on the control plane). To let clients request a
 longer, bounded timeout, set a positive `DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX` on
 the control plane. For example, with `DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX=15m`:
 

--- a/configresolve/cliflags.go
+++ b/configresolve/cliflags.go
@@ -29,7 +29,7 @@ func RegisterCLIInputsFlags(fs *flag.FlagSet) func() CLIInputs {
 	keyFile := fs.String("key", "", "TLS private key file (env: DUCKGRES_KEY)")
 	filePersistence := fs.Bool("file-persistence", false, "Persist DuckDB to <data-dir>/<username>.duckdb instead of in-memory (env: DUCKGRES_FILE_PERSISTENCE)")
 	processIsolation := fs.Bool("process-isolation", false, "Enable process isolation (spawn child process per connection)")
-	idleTimeout := fs.String("idle-timeout", "", "Connection idle timeout: close a connection idle (no traffic) this long, freeing its worker (e.g., '30m', '1h', '-1s' to disable). Default 24h standalone, 60s control-plane where idle connections pin a worker (env: DUCKGRES_IDLE_TIMEOUT)")
+	idleTimeout := fs.String("idle-timeout", "", "Connection idle timeout: close a connection idle (no traffic) this long, freeing its worker (e.g., '30m', '1h', '-1s' to disable). Default 24h standalone, 5m control-plane where idle connections pin a worker (env: DUCKGRES_IDLE_TIMEOUT)")
 	sessionInitTimeout := fs.String("session-init-timeout", "", "Session startup metadata/probe timeout (e.g., '10s', '30s') (env: DUCKGRES_SESSION_INIT_TIMEOUT)")
 	memoryLimit := fs.String("memory-limit", "", "DuckDB memory_limit per session (e.g., '4GB') (env: DUCKGRES_MEMORY_LIMIT)")
 	threads := fs.Int("threads", 0, "DuckDB threads per session (env: DUCKGRES_THREADS)")

--- a/server/exports.go
+++ b/server/exports.go
@@ -86,7 +86,20 @@ func NewClientConn(s *Server, conn net.Conn, reader *bufio.Reader, writer *bufio
 // so an idle connection is closed after this long — its message loop hits the
 // read deadline, returns, and the worker is released back to the hot-idle pool.
 // Operators override it with --idle-timeout (a negative value disables it).
-const DefaultControlPlaneIdleTimeout = 60 * time.Second
+//
+// This was 60s, which reclaimed a pinned worker quickly but broke any client
+// that pauses between statements. A batch client running its DAG across
+// several parallel connections idles a connection whenever a thread waits on
+// work elsewhere. It then finds the connection closed and reports a lost
+// connection rather than an idle one — and a client cannot safely replay a
+// write that may already have committed, so the failure reaches the user.
+//
+// 5m keeps the reclaim bounded while covering the gaps a batch or BI client
+// leaves between statements. Deployments that want tighter worker density set
+// --idle-timeout / DUCKGRES_IDLE_TIMEOUT; a client that needs longer asks for
+// it per connection with duckgres.idle_timeout, bounded by
+// DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX.
+const DefaultControlPlaneIdleTimeout = 5 * time.Minute
 
 // NormalizeIdleTimeout resolves a configured connection idle timeout: zero means
 // "unset" → use zeroDefault; a negative value means "explicitly disabled" → 0

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -31,6 +31,40 @@ func TestCancelQueryDoesNotLogSecretKey(t *testing.T) {
 	}
 }
 
+// TestDefaultControlPlaneIdleTimeout pins the control-plane idle-timeout
+// default. The value is a product decision, not an implementation detail: it
+// decides whether a client that pauses between statements keeps its connection.
+//
+// At 60s it did not. A batch client spreading its DAG over parallel
+// connections idles one whenever a thread waits on work elsewhere, so the
+// control plane closed it and the client reported a lost connection on its
+// next statement. A client cannot safely replay a write that may already have
+// committed, so that surfaced as a failed run rather than a reconnect.
+//
+// The floor is what matters here. Anything at or below a minute reintroduces
+// that failure; the exact value above it is a density trade-off operators can
+// make with --idle-timeout.
+func TestDefaultControlPlaneIdleTimeout(t *testing.T) {
+	if DefaultControlPlaneIdleTimeout != 5*time.Minute {
+		t.Errorf("DefaultControlPlaneIdleTimeout = %v, want 5m", DefaultControlPlaneIdleTimeout)
+	}
+	// A client that pauses between statements must survive the pause.
+	if DefaultControlPlaneIdleTimeout <= time.Minute {
+		t.Errorf(
+			"DefaultControlPlaneIdleTimeout = %v: at or below a minute a batch client "+
+				"loses idle connections between statements",
+			DefaultControlPlaneIdleTimeout,
+		)
+	}
+	// An abandoned connection still has to give its worker back promptly.
+	if DefaultControlPlaneIdleTimeout > 15*time.Minute {
+		t.Errorf(
+			"DefaultControlPlaneIdleTimeout = %v: too long to hold a pinned worker by default",
+			DefaultControlPlaneIdleTimeout,
+		)
+	}
+}
+
 func TestNormalizeIdleTimeout(t *testing.T) {
 	const def = 60 * time.Second
 	cases := []struct {

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -3041,15 +3041,20 @@ admin_per_org_workers() { # org password
 
 # ---- connection idle timeout: idle conn reaped, worker freed ----------------
 # An idle client connection pins a worker (one session per worker), so the
-# control plane defaults to a short connection idle timeout (server.Default
-# ControlPlaneIdleTimeout, 60s): a connection with no traffic for that long is
-# closed by the message loop's read deadline, DestroySession runs, and the
-# worker returns to hot-idle. We hold a connection idle-in-transaction PAST the
-# timeout and assert its session disappears from /queries while our client is
-# still connected (so the reap is the CP's, not our client exiting). The unit
-# tests (TestNormalizeIdleTimeout + TestMessageLoopIdleTimeoutClosesConnection)
-# are the deterministic gate for the mechanism; this proves the real default
-# fires end-to-end in-cluster.
+# control plane closes a connection with no traffic: the message loop hits its
+# read deadline, DestroySession runs, and the worker returns to hot-idle. We
+# hold a connection idle-in-transaction PAST the timeout and assert its session
+# disappears from /queries while our client is still connected (so the reap is
+# the CP's, not our client exiting). The unit tests (TestNormalizeIdleTimeout +
+# TestMessageLoopIdleTimeoutClosesConnection) are the deterministic gate for
+# the mechanism; this proves it fires end-to-end in-cluster.
+#
+# The timeout is driven from DUCKGRES_IDLE_TIMEOUT=20s in manifests.tmpl.yaml,
+# NOT from the product default. The default is 5m (server.Default
+# ControlPlaneIdleTimeout), so riding it would cost six minutes of Job time per
+# run to watch one reap. What this test is for is the reap path, which is the
+# same at either value. TestDefaultControlPlaneIdleTimeout pins the default.
+# If you change the manifest value, change the two waits below with it.
 #
 # TIER AUDIT — the assertion's MEANING shifted, its mechanics did not. With
 # lazy acquisition an idle connection may hold NO session at all (nothing to
@@ -3068,9 +3073,9 @@ conn_idle_timeout_reaps_session() { # org password
       | jq -r --arg o "$org" '[.queries[]? | select(.org==$o and .user=="root") | .worker_id] | sort | join(" ")'
   }
   before="$(rootwids)"
-  # Hold a connection idle-in-transaction for 150s (well past the 60s timeout):
+  # Hold a connection idle-in-transaction for 90s (well past the 20s timeout):
   # send BEGIN, then keep stdin open so psql waits and issues no further query.
-  ( printf 'BEGIN;\n'; sleep 150 ) | PGPASSWORD="$pw" psql \
+  ( printf 'BEGIN;\n'; sleep 90 ) | PGPASSWORD="$pw" psql \
       "sslmode=require host=$org$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=ducklake" \
       -v ON_ERROR_STOP=1 -qtA >/dev/null 2>&1 &
   bg=$!
@@ -3087,17 +3092,18 @@ conn_idle_timeout_reaps_session() { # org password
   done
   [ -n "$wid" ] || { cleanup_ir; fail "conn_idle_timeout: idle session never appeared for $org"; }
   log "conn idle timeout: idle session on worker $wid — waiting for the CP to reap it"
-  # Must vanish from /queries within ~90s (60s timeout + grace), while our client
-  # is STILL alive (kill -0) so the disappearance is the CP reaping, not us.
+  # Must vanish from /queries within ~60s (20s timeout + generous grace), while
+  # our client is STILL alive (kill -0) so the disappearance is the CP reaping,
+  # not us.
   gone="" a=0
-  while [ "$a" -lt 30 ]; do
+  while [ "$a" -lt 20 ]; do
     kill -0 "$bg" 2>/dev/null || { cleanup_ir; fail "conn_idle_timeout: our client exited before reap — inconclusive"; }
     present="$(curl -fsS -H "$H" "$API/api/v1/queries" | jq -r --argjson w "$wid" 'any(.queries[]?; .worker_id==$w)')"
     [ "$present" = "false" ] && { gone=1; break; }
     sleep 3; a=$((a + 1))
   done
   cleanup_ir
-  [ -n "$gone" ] || fail "conn_idle_timeout: idle session on worker $wid was NOT reaped within ~90s (idle timeout not enforced)"
+  [ -n "$gone" ] || fail "conn_idle_timeout: idle session on worker $wid was NOT reaped within ~60s (idle timeout not enforced)"
   log "conn idle timeout: idle session reaped, worker $wid freed on $org"
 }
 

--- a/tests/mw-dev/e2e/harness.sh
+++ b/tests/mw-dev/e2e/harness.sh
@@ -3049,12 +3049,19 @@ admin_per_org_workers() { # org password
 # TestMessageLoopIdleTimeoutClosesConnection) are the deterministic gate for
 # the mechanism; this proves it fires end-to-end in-cluster.
 #
-# The timeout is driven from DUCKGRES_IDLE_TIMEOUT=20s in manifests.tmpl.yaml,
-# NOT from the product default. The default is 5m (server.Default
-# ControlPlaneIdleTimeout), so riding it would cost six minutes of Job time per
-# run to watch one reap. What this test is for is the reap path, which is the
-# same at either value. TestDefaultControlPlaneIdleTimeout pins the default.
-# If you change the manifest value, change the two waits below with it.
+# This connection asks for its OWN short idle timeout with
+# duckgres.idle_timeout, allowed by DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX in
+# manifests.tmpl.yaml. It does not ride the product default, which is 5m
+# (server.DefaultControlPlaneIdleTimeout): riding that would cost six minutes
+# of Job time per run to watch one reap. What this test is for is the reap
+# path, which is the same at any value, and TestDefaultControlPlaneIdleTimeout
+# pins the default itself.
+#
+# Do NOT "simplify" this by shortening DUCKGRES_IDLE_TIMEOUT CP-wide instead.
+# admin_idle_session_flagged holds a connection idle-in-transaction for 30s and
+# admin_cancel_by_worker for up to 90s; a short CP-wide default reaps those
+# mid-assertion. Scoping the short timeout to this one connection is what keeps
+# them independent. It also gives the client-override path its only e2e cover.
 #
 # TIER AUDIT — the assertion's MEANING shifted, its mechanics did not. With
 # lazy acquisition an idle connection may hold NO session at all (nothing to
@@ -3075,7 +3082,7 @@ conn_idle_timeout_reaps_session() { # org password
   before="$(rootwids)"
   # Hold a connection idle-in-transaction for 90s (well past the 20s timeout):
   # send BEGIN, then keep stdin open so psql waits and issues no further query.
-  ( printf 'BEGIN;\n'; sleep 90 ) | PGPASSWORD="$pw" psql \
+  ( printf 'BEGIN;\n'; sleep 90 ) | PGOPTIONS="-c duckgres.idle_timeout=20s" PGPASSWORD="$pw" psql \
       "sslmode=require host=$org$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=ducklake" \
       -v ON_ERROR_STOP=1 -qtA >/dev/null 2>&1 &
   bg=$!
@@ -3355,7 +3362,7 @@ admin_cancel_by_worker() { # org password
   log "admin: cancel a live session by worker id on $org"
   # Hold longer than the appear-poll budget (30×2s) so a slow cold-start can't
   # exit the client before the session is observed (we cancel it well before
-  # the 60s idle timeout anyway).
+  # the 5m idle timeout anyway).
   ( printf 'BEGIN;\n'; sleep 90 ) | PGPASSWORD="$pw" psql \
       "sslmode=require host=$org$SNI_SUFFIX hostaddr=$CP_IP port=5432 user=root dbname=ducklake" \
       -v ON_ERROR_STOP=1 -qtA >/dev/null 2>&1 &

--- a/tests/mw-dev/manifests.tmpl.yaml
+++ b/tests/mw-dev/manifests.tmpl.yaml
@@ -336,13 +336,15 @@ spec:
             # settle and two org-default-profile propagation waits — which drop
             # from 40s each to CONFIG_POLL_SETTLE (12s) on the back of it.
             - { name: DUCKGRES_CONFIG_POLL_INTERVAL, value: "5s" }
-            # Short connection idle timeout for CI only. The product default is
-            # server.DefaultControlPlaneIdleTimeout (5m), which would make
-            # conn_idle_timeout_reaps_session hold a connection for six minutes
-            # to observe one reap. The assertion is about the reap MECHANISM, so
-            # it is driven from an explicit value here; the default itself is
-            # pinned by TestDefaultControlPlaneIdleTimeout.
-            - { name: DUCKGRES_IDLE_TIMEOUT, value: "20s" }
+            # Let a connection request its own idle timeout, so
+            # conn_idle_timeout_reaps_session can ask for a short one instead of
+            # waiting out the 5m default. Do NOT shorten DUCKGRES_IDLE_TIMEOUT
+            # here to achieve that: other assertions hold a connection
+            # idle-in-transaction (admin_idle_session_flagged for 30s,
+            # admin_cancel_by_worker for up to 90s) and a short CP-wide default
+            # would reap those mid-assertion. This also gives the client-override
+            # path (server.ValidateClientIdleTimeoutOption) its only e2e coverage.
+            - { name: DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX, value: "10m" }
             - name: DUCKGRES_INTERNAL_SECRET
               valueFrom: { secretKeyRef: { name: duckgres-tokens, key: internal-secret } }
             # Previous internal secrets still accepted during rotation; the

--- a/tests/mw-dev/manifests.tmpl.yaml
+++ b/tests/mw-dev/manifests.tmpl.yaml
@@ -336,6 +336,13 @@ spec:
             # settle and two org-default-profile propagation waits — which drop
             # from 40s each to CONFIG_POLL_SETTLE (12s) on the back of it.
             - { name: DUCKGRES_CONFIG_POLL_INTERVAL, value: "5s" }
+            # Short connection idle timeout for CI only. The product default is
+            # server.DefaultControlPlaneIdleTimeout (5m), which would make
+            # conn_idle_timeout_reaps_session hold a connection for six minutes
+            # to observe one reap. The assertion is about the reap MECHANISM, so
+            # it is driven from an explicit value here; the default itself is
+            # pinned by TestDefaultControlPlaneIdleTimeout.
+            - { name: DUCKGRES_IDLE_TIMEOUT, value: "20s" }
             - name: DUCKGRES_INTERNAL_SECRET
               valueFrom: { secretKeyRef: { name: duckgres-tokens, key: internal-secret } }
             # Previous internal secrets still accepted during rotation; the


### PR DESCRIPTION
## The problem

An idle client connection pins a worker, so the control plane closes a connection that sends no traffic. The default was **60 seconds**.

That reclaims a pinned worker quickly. It also breaks any client that pauses between statements.

A batch client spreads its DAG over several parallel connections. Whenever one thread waits on work elsewhere, its connection sits idle. At 60s the control plane closed it, and the client hit a dead socket on its next statement.

Two things make that worse than a reconnect:

- **The client cannot tell a reclaim from a fault.** It sees a closed connection, not "you were idle". So it cannot distinguish our capacity policy from a network failure.
- **A write cannot be safely replayed.** With autocommit, a connection can drop after the server committed but before the ack. A careful client re-raises rather than double-applying, so a write landing on a reclaimed connection fails the run instead of retrying.

Observed on a production batch tenant: every idle close landed on exactly the same value, hundreds of times a day.

| idle before close | value |
| --- | --- |
| min | 60.0s |
| p50 | 60.0s |
| max | 60.0s |

## The change

`DefaultControlPlaneIdleTimeout` goes from `60 * time.Second` to `5 * time.Minute`.

5m still bounds the reclaim, and covers the gaps a batch or BI client leaves between statements. Nothing else about the mechanism changes: the message loop's read deadline still fires, `DestroySession` still runs, the worker still returns to hot-idle.

The escape hatches are unchanged and now matter less often:

- Operators wanting tighter worker density set `--idle-timeout` / `DUCKGRES_IDLE_TIMEOUT`.
- A client needing longer asks per connection with `duckgres.idle_timeout`, bounded by `DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX`.

## Risk

An idle connection now holds its worker for up to 5 minutes instead of 1. Two consequences worth naming:

- **Worker density drops for idle-heavy workloads.** An org with many parked connections holds more workers, so an org at its worker cap can hit `WorkerClaimMissReasonOrgCap` sooner. Per-org caps still bound the total, and the fast-fail path is unchanged.
- **An abandoned connection takes longer to release.** Still bounded, and still five minutes short of the 24h standalone default.

Deployments that need the old behaviour set `DUCKGRES_IDLE_TIMEOUT=60s` and get it back exactly.

## Tests

`TestDefaultControlPlaneIdleTimeout` pins the value, and more usefully the **floor**: at or below a minute the failure above returns. It also caps the value, so nobody quietly turns a bounded reclaim into a 15-minute one. The exact number between those bounds is a density trade-off; the bounds are the contract.

`TestNormalizeIdleTimeout` is unaffected — it passes its default in as a parameter, so it tests the resolution function rather than the constant.

**The e2e assertion is decoupled from the default.** `conn_idle_timeout_reaps_session` used to ride it: hold a connection 150s, watch the reap inside 90s. At a 5m default that becomes six minutes of Job time per run to observe one reap. The manifest now sets `DUCKGRES_IDLE_TIMEOUT=20s` and the harness drives from that, with its waits shortened to match. The test is about the reap path, which is identical at any value, and it now runs faster than before. The comment says so, and points at the unit test for the default.

Docs updated in the same PR per CLAUDE.md: the CLAUDE.md worker-session line, the `--idle-timeout` help text in `configresolve/cliflags.go`, and both README mentions (the prose and the env table, which claimed a flat `24h` and now distinguishes standalone from control-plane).

## Verification

`go build`, `go vet`, `go test ./server/... ./configresolve/...` and `go test -tags kubernetes ./controlplane/` all pass. `bash -n` clean on the harness. The added manifest entry parses as YAML on its own; the file as a whole is a `.tmpl.yaml` and does not parse standalone either before or after this change, because of its `${NAMESPACE}` substitutions.

Not verified here: the e2e harness itself, which only runs in CI against the real mw-dev cluster. The new 20s timings are derived from the old 60s ones with the same proportional grace, but this PR's first CI run is what actually exercises them.
