### PR TITLE
Add Trino readiness to scenario runner

### DIFF
--- a/controlplane/admin/api.go
+++ b/controlplane/admin/api.go
@@ -279,7 +279,7 @@ func (s *gormAPIStore) CreateOrg(org *configstore.Org, teamID int64, schemaName 
 
 func (s *gormAPIStore) GetOrg(name string) (*configstore.Org, error) {
 	var org configstore.Org
-	if err := s.db().Preload("Users").Preload("Warehouse").Preload("Teams").First(&org, "name = ?", name).Error; err != nil {
+	if err := s.db().Preload("Users").Preload("Warehouse").Preload("Teams").Preload("Trino").First(&org, "name = ?", name).Error; err != nil {
 		return nil, err
 	}
 	return &org, nil

--- a/controlplane/admin/api_postgres_test.go
+++ b/controlplane/admin/api_postgres_test.go
@@ -104,6 +104,33 @@ func TestAdminAdmissionConfigMutationsSerializePostgres(t *testing.T) {
 	}
 }
 
+func TestAdminGetOrgPreloadsTrinoPostgres(t *testing.T) {
+	store := newPostgresConfigStore(t)
+	const orgID = "admin-get-org-trino"
+	if err := store.DB().Create(&configstore.Org{Name: orgID, DatabaseName: "admin-get-org-trino"}).Error; err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	if err := store.DB().Create(&configstore.ManagedWarehouseTrino{
+		OrgID:   orgID,
+		Enabled: true,
+		Tier:    "free",
+		State:   configstore.ManagedWarehouseStateReady,
+	}).Error; err != nil {
+		t.Fatalf("create Trino row: %v", err)
+	}
+
+	org, err := newGormAPIStore(store).(*gormAPIStore).GetOrg(orgID)
+	if err != nil {
+		t.Fatalf("GetOrg returned error: %v", err)
+	}
+	if org.Trino == nil {
+		t.Fatal("GetOrg did not preload the Trino association")
+	}
+	if !org.Trino.Enabled || org.Trino.State != configstore.ManagedWarehouseStateReady {
+		t.Fatalf("preloaded Trino row = %+v, want enabled ready", org.Trino)
+	}
+}
+
 // TestAdminUpdateOrgRenamesDatabaseNamePostgres exercises the gorm store's
 // database_name threading against real Postgres: a non-empty value renames
 // (the break-glass fix for unroutable stored names), an empty value preserves

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -57,6 +57,37 @@ The isolated control plane's default worker request is configurable through
 `scenario-dev.yml` explicitly overrides them to 2 CPU and 8Gi for the frozen
 perf workload. Direct `run.sh` callers can make the same explicit override.
 
+### Scenario Trino readiness
+
+Scenarios that opt an org into Trino in their `provision_warehouse` request can
+use a `wait_trino_ready` step before a Trino workload:
+
+```yaml
+- id: wait_trino_ready
+  type: wait_trino_ready
+  depends_on: [wait_ready]
+  with:
+    org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
+    timeout: 5m
+    poll_interval: 5s
+```
+
+The step polls the authenticated org detail API (`GET
+/api/v1/orgs/:id/trino`) until Trino is enabled, its latest reconcile state is
+`ready`, and the control plane can reach the cell. It fails immediately when
+the reconcile state is `failed`, preserving `status_message` in the scenario
+error. The scenario runner defaults are a 15-minute timeout and 10-second poll
+interval; a step can override them with `timeout`, `poll_interval`, or
+`max_attempts`.
+
+This readiness boundary deliberately does not claim that a newly projected
+tenant password has reloaded in Trino. Kubernetes Secret projection and the
+file authenticator refresh can lag the reconcile state, so the first
+authenticated Trino query must still retry within its own bounded startup
+window. On failure, inspect the org detail response first: `failed` is a
+catalog/projection failure, while `ready` plus `available: false` points to the
+cell or its observer credentials.
+
 ## Isolated Trino lane
 
 The Trino lane never uses the shared mw-dev Trino namespace or coordinator.

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -74,11 +74,11 @@ use a `wait_trino_ready` step before a Trino workload:
 
 The step polls the authenticated org detail API (`GET
 /api/v1/orgs/:id/trino`) until Trino is enabled, its latest reconcile state is
-`ready`, and the control plane can reach the cell. It fails immediately when
-the reconcile state is `failed`, preserving `status_message` in the scenario
-error. The scenario runner defaults are a 15-minute timeout and 10-second poll
-interval; a step can override them with `timeout`, `poll_interval`, or
-`max_attempts`.
+`ready`, its principal and catalog are resolved for the reported cell, and the
+control plane can reach that cell. It fails immediately when the reconcile
+state is `failed`, preserving `status_message` in the scenario error. The
+scenario runner defaults are a 15-minute timeout and 10-second poll interval;
+a step can override them with `timeout`, `poll_interval`, or `max_attempts`.
 
 This readiness boundary deliberately does not claim that a newly projected
 tenant password has reloaded in Trino. Kubernetes Secret projection and the

--- a/tests/mw-dev/scenario/provision/client.go
+++ b/tests/mw-dev/scenario/provision/client.go
@@ -63,6 +63,37 @@ type WarehouseStatus struct {
 	Bucket             string             `json:"bucket,omitempty"`
 }
 
+// TrinoStatus is the org-scoped admin API envelope returned by
+// GET /api/v1/orgs/:id/trino. The Status detail is absent while Trino is not
+// enabled; once enabled it carries the provisioner's authoritative lifecycle
+// state and the derived tenant identity.
+type TrinoStatus struct {
+	Cell      TrinoCell       `json:"cell"`
+	Enabled   bool            `json:"enabled"`
+	Available bool            `json:"available"`
+	Status    *TrinoOrgStatus `json:"status,omitempty"`
+}
+
+type TrinoCell struct {
+	ID             string `json:"id"`
+	CoordinatorURL string `json:"coordinator_url,omitempty"`
+}
+
+type TrinoOrgStatus struct {
+	Org              string     `json:"org"`
+	Principal        string     `json:"principal"`
+	Catalog          string     `json:"catalog"`
+	TrinoCatalogName string     `json:"trino_catalog_name"`
+	Tier             string     `json:"tier"`
+	Cell             string     `json:"cell"`
+	State            string     `json:"state"`
+	StatusMessage    string     `json:"status_message,omitempty"`
+	ReadyAt          *time.Time `json:"ready_at,omitempty"`
+	FailedAt         *time.Time `json:"failed_at,omitempty"`
+	RunningQueries   int        `json:"running_queries"`
+	QueuedQueries    int        `json:"queued_queries"`
+}
+
 type ConnectionDetails struct {
 	Host     string `json:"host"`
 	Port     int    `json:"port"`
@@ -115,6 +146,14 @@ func (c *Client) WarehouseStatus(ctx context.Context, orgID string) (WarehouseSt
 	return resp, nil
 }
 
+func (c *Client) TrinoStatus(ctx context.Context, orgID string) (TrinoStatus, error) {
+	var resp TrinoStatus
+	if err := c.doJSON(ctx, http.MethodGet, orgPath(orgID, "trino"), nil, &resp, http.StatusOK); err != nil {
+		return TrinoStatus{}, err
+	}
+	return resp, nil
+}
+
 func (c *Client) Deprovision(ctx context.Context, orgID string) (DeprovisionResponse, error) {
 	var resp DeprovisionResponse
 	path := orgPath(orgID, "deprovision")
@@ -131,6 +170,58 @@ func (c *Client) WaitWarehouseReady(ctx context.Context, orgID string, opts Wait
 func (c *Client) WaitWarehouseDeleted(ctx context.Context, orgID string, opts WaitOptions) (WarehouseStatus, error) {
 	opts.AcceptNotFound = true
 	return c.waitForState(ctx, orgID, WarehouseStateDeleted, opts)
+}
+
+// WaitTrinoReady waits for both the provisioner's lifecycle state and the
+// admin API's live coordinator observation. A ready config-store row alone is
+// not sufficient when the cell is unavailable; the later query smoke still
+// owns tenant-auth verification because Secret projection and Trino's file
+// refresh can lag this status briefly.
+func (c *Client) WaitTrinoReady(ctx context.Context, orgID string, opts WaitOptions) (TrinoStatus, error) {
+	waitCtx, cancel := contextWithOptionalTimeout(ctx, opts.Timeout)
+	defer cancel()
+
+	interval := opts.PollInterval
+	if interval <= 0 {
+		interval = defaultPollInterval
+	}
+	sleep := opts.Sleep
+	if sleep == nil {
+		sleep = waitSleep
+	}
+
+	var last TrinoStatus
+	for attempts := 1; ; attempts++ {
+		status, err := c.TrinoStatus(waitCtx, orgID)
+		if err != nil {
+			if waitCtx.Err() != nil {
+				return last, trinoWaitContextError(waitCtx, orgID)
+			}
+			return last, err
+		}
+		last = status
+		if status.Enabled && status.Available && status.Status != nil && status.Status.State == WarehouseStateReady {
+			return status, nil
+		}
+		if status.Status != nil && status.Status.State == WarehouseStateFailed {
+			return status, classified(ErrorClassProvisionFailed, fmt.Errorf("%w for %s: %s", ErrTrinoFailed, orgID, status.Status.StatusMessage))
+		}
+		if opts.MaxAttempts > 0 && attempts >= opts.MaxAttempts {
+			return status, trinoWaitTimeoutError(orgID)
+		}
+		if err := sleep(waitCtx, interval); err != nil {
+			if waitCtx.Err() != nil {
+				return status, trinoWaitContextError(waitCtx, orgID)
+			}
+			if errors.Is(err, context.Canceled) {
+				return status, err
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				return status, trinoWaitTimeoutError(orgID)
+			}
+			return status, classified(ErrorClassProvisionAPI, fmt.Errorf("sleep while waiting for %s Trino readiness: %w", orgID, err))
+		}
+	}
 }
 
 func (c *Client) doJSON(ctx context.Context, method, path string, body any, out any, expectedStatus int) error {
@@ -191,16 +282,7 @@ func (c *Client) waitForState(ctx context.Context, orgID, target string, opts Wa
 	}
 	sleep := opts.Sleep
 	if sleep == nil {
-		sleep = func(ctx context.Context, d time.Duration) error {
-			timer := time.NewTimer(d)
-			defer timer.Stop()
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-timer.C:
-				return nil
-			}
-		}
+		sleep = waitSleep
 	}
 
 	var last WarehouseStatus
@@ -241,6 +323,17 @@ func (c *Client) waitForState(ctx context.Context, orgID, target string, opts Wa
 	}
 }
 
+func waitSleep(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 func contextWithOptionalTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	if timeout <= 0 {
 		return ctx, func() {}
@@ -255,6 +348,17 @@ func waitTimeoutError(target, orgID string) error {
 func waitContextError(ctx context.Context, target, orgID string) error {
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return waitTimeoutError(target, orgID)
+	}
+	return ctx.Err()
+}
+
+func trinoWaitTimeoutError(orgID string) error {
+	return classified(ErrorClassWaitTimeout, fmt.Errorf("%w: org %s did not become ready and available", ErrTrinoWaitTimeout, orgID))
+}
+
+func trinoWaitContextError(ctx context.Context, orgID string) error {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return trinoWaitTimeoutError(orgID)
 	}
 	return ctx.Err()
 }

--- a/tests/mw-dev/scenario/provision/client.go
+++ b/tests/mw-dev/scenario/provision/client.go
@@ -200,7 +200,7 @@ func (c *Client) WaitTrinoReady(ctx context.Context, orgID string, opts WaitOpti
 			return last, err
 		}
 		last = status
-		if status.Enabled && status.Available && status.Status != nil && status.Status.State == WarehouseStateReady {
+		if trinoReady(status) {
 			return status, nil
 		}
 		if status.Status != nil && status.Status.State == WarehouseStateFailed {
@@ -222,6 +222,18 @@ func (c *Client) WaitTrinoReady(ctx context.Context, orgID string, opts WaitOpti
 			return status, classified(ErrorClassProvisionAPI, fmt.Errorf("sleep while waiting for %s Trino readiness: %w", orgID, err))
 		}
 	}
+}
+
+func trinoReady(status TrinoStatus) bool {
+	if !status.Enabled || !status.Available || status.Status == nil {
+		return false
+	}
+	detail := status.Status
+	return detail.State == WarehouseStateReady &&
+		detail.Principal != "" &&
+		detail.Catalog != "" &&
+		status.Cell.ID != "" &&
+		detail.Cell == status.Cell.ID
 }
 
 func (c *Client) doJSON(ctx context.Context, method, path string, body any, out any, expectedStatus int) error {

--- a/tests/mw-dev/scenario/provision/client_test.go
+++ b/tests/mw-dev/scenario/provision/client_test.go
@@ -204,6 +204,192 @@ func TestClientWaitWarehouseReadyFailsFastOnFailed(t *testing.T) {
 	}
 }
 
+func TestClientTrinoStatusUsesOrgDetailEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/orgs/scenario-org/trino" {
+			t.Fatalf("path = %s, want org Trino detail path", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Duckgres-Internal-Secret"); got != "internal-secret" {
+			t.Fatalf("internal secret header = %q, want internal-secret", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"cell":      map[string]any{"id": "cell-001"},
+			"enabled":   true,
+			"available": true,
+			"status": map[string]any{
+				"org":                "scenario-org",
+				"principal":          "scenario-db",
+				"catalog":            "org_scenario_db",
+				"trino_catalog_name": "org_scenario_db",
+				"tier":               "free",
+				"cell":               "cell-001",
+				"state":              "ready",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		BaseURL:        server.URL,
+		InternalSecret: "internal-secret",
+		HTTPClient:     server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+	status, err := client.TrinoStatus(context.Background(), "scenario-org")
+	if err != nil {
+		t.Fatalf("TrinoStatus returned error: %v", err)
+	}
+	if !status.Enabled || !status.Available || status.Status == nil {
+		t.Fatalf("Trino status = %+v, want enabled and available detail", status)
+	}
+	if status.Status.Principal != "scenario-db" || status.Status.Catalog != "org_scenario_db" {
+		t.Fatalf("Trino identity = %+v, want scenario-db/org_scenario_db", status.Status)
+	}
+}
+
+func TestClientWaitTrinoReadyPollsUntilEnabledAvailableAndReady(t *testing.T) {
+	responses := []map[string]any{
+		{
+			"cell":    map[string]any{"id": "cell-001"},
+			"enabled": false,
+		},
+		{
+			"cell":      map[string]any{"id": "cell-001"},
+			"enabled":   true,
+			"available": true,
+			"status": map[string]any{
+				"org":   "scenario-org",
+				"state": "pending",
+			},
+		},
+		{
+			"cell":      map[string]any{"id": "cell-001"},
+			"enabled":   true,
+			"available": false,
+			"status": map[string]any{
+				"org":   "scenario-org",
+				"state": "ready",
+			},
+		},
+		{
+			"cell":      map[string]any{"id": "cell-001"},
+			"enabled":   true,
+			"available": true,
+			"status": map[string]any{
+				"org":       "scenario-org",
+				"principal": "scenario-db",
+				"catalog":   "org_scenario_db",
+				"cell":      "cell-001",
+				"state":     "ready",
+			},
+		},
+	}
+	polls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(responses[polls])
+		polls++
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+	var sleeps []time.Duration
+	status, err := client.WaitTrinoReady(context.Background(), "scenario-org", WaitOptions{
+		PollInterval: 25 * time.Millisecond,
+		Sleep: func(_ context.Context, d time.Duration) error {
+			sleeps = append(sleeps, d)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("WaitTrinoReady returned error: %v", err)
+	}
+	if status.Status == nil || status.Status.State != WarehouseStateReady {
+		t.Fatalf("Trino status = %+v, want ready detail", status)
+	}
+	if polls != 4 {
+		t.Fatalf("polls = %d, want 4", polls)
+	}
+	if len(sleeps) != 3 {
+		t.Fatalf("sleeps = %#v, want three sleeps", sleeps)
+	}
+}
+
+func TestClientWaitTrinoReadyFailsFastOnFailed(t *testing.T) {
+	polls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		polls++
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":   true,
+			"available": true,
+			"status": map[string]any{
+				"org":            "scenario-org",
+				"state":          "failed",
+				"status_message": "catalog projection failed",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+	_, err = client.WaitTrinoReady(context.Background(), "scenario-org", WaitOptions{
+		Sleep: func(context.Context, time.Duration) error {
+			t.Fatal("sleep should not be called for failed Trino state")
+			return nil
+		},
+	})
+	if !errors.Is(err, ErrTrinoFailed) {
+		t.Fatalf("WaitTrinoReady error = %v, want ErrTrinoFailed", err)
+	}
+	if polls != 1 {
+		t.Fatalf("polls = %d, want 1", polls)
+	}
+	if !strings.Contains(err.Error(), "catalog projection failed") {
+		t.Fatalf("error = %v, want status message", err)
+	}
+}
+
+func TestClientWaitTrinoReadyReportsUnavailableTimeout(t *testing.T) {
+	polls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		polls++
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":   true,
+			"available": false,
+			"status": map[string]any{
+				"org":   "scenario-org",
+				"state": "ready",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+	_, err = client.WaitTrinoReady(context.Background(), "scenario-org", WaitOptions{
+		MaxAttempts: 2,
+		Sleep:       func(context.Context, time.Duration) error { return nil },
+	})
+	if !errors.Is(err, ErrTrinoWaitTimeout) {
+		t.Fatalf("WaitTrinoReady error = %v, want ErrTrinoWaitTimeout", err)
+	}
+	if polls != 2 {
+		t.Fatalf("polls = %d, want 2", polls)
+	}
+}
+
 func TestClientDeprovisionSendsExpectedRequest(t *testing.T) {
 	called := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tests/mw-dev/scenario/provision/client_test.go
+++ b/tests/mw-dev/scenario/provision/client_test.go
@@ -322,6 +322,72 @@ func TestClientWaitTrinoReadyPollsUntilEnabledAvailableAndReady(t *testing.T) {
 	}
 }
 
+func TestClientWaitTrinoReadyRequiresResolvedIdentityAndMatchingCell(t *testing.T) {
+	responses := []map[string]any{
+		{
+			"cell":      map[string]any{"id": "cell-001"},
+			"enabled":   true,
+			"available": true,
+			"status": map[string]any{
+				"org":   "scenario-org",
+				"cell":  "cell-001",
+				"state": "ready",
+			},
+		},
+		{
+			"cell":      map[string]any{"id": "cell-001"},
+			"enabled":   true,
+			"available": true,
+			"status": map[string]any{
+				"org":       "scenario-org",
+				"principal": "scenario-db",
+				"catalog":   "org_scenario_db",
+				"cell":      "cell-002",
+				"state":     "ready",
+			},
+		},
+		{
+			"cell":      map[string]any{"id": "cell-001"},
+			"enabled":   true,
+			"available": true,
+			"status": map[string]any{
+				"org":       "scenario-org",
+				"principal": "scenario-db",
+				"catalog":   "org_scenario_db",
+				"cell":      "cell-001",
+				"state":     "ready",
+			},
+		},
+	}
+	polls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(responses[polls])
+		polls++
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+	var sleeps int
+	status, err := client.WaitTrinoReady(context.Background(), "scenario-org", WaitOptions{
+		Sleep: func(context.Context, time.Duration) error {
+			sleeps++
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("WaitTrinoReady returned error: %v", err)
+	}
+	if status.Status == nil || status.Status.Cell != status.Cell.ID {
+		t.Fatalf("Trino status = %+v, want matching cell assignment", status)
+	}
+	if polls != 3 || sleeps != 2 {
+		t.Fatalf("polls/sleeps = %d/%d, want 3/2", polls, sleeps)
+	}
+}
+
 func TestClientWaitTrinoReadyFailsFastOnFailed(t *testing.T) {
 	polls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/tests/mw-dev/scenario/provision/errors.go
+++ b/tests/mw-dev/scenario/provision/errors.go
@@ -21,7 +21,9 @@ const (
 var (
 	ErrUnexpectedStatus = errors.New("unexpected provisioning api status")
 	ErrWarehouseFailed  = errors.New("warehouse failed")
+	ErrTrinoFailed      = errors.New("trino provisioning failed")
 	ErrWaitTimeout      = errors.New("warehouse wait timeout")
+	ErrTrinoWaitTimeout = errors.New("trino wait timeout")
 )
 
 type classifiedError struct {

--- a/tests/mw-dev/scenario/provision/steps.go
+++ b/tests/mw-dev/scenario/provision/steps.go
@@ -14,6 +14,7 @@ import (
 const (
 	StepTypeProvisionWarehouse   = "provision_warehouse"
 	StepTypeWaitWarehouseReady   = "wait_warehouse_ready"
+	StepTypeWaitTrinoReady       = "wait_trino_ready"
 	StepTypeDeprovisionWarehouse = "deprovision_warehouse"
 )
 
@@ -33,6 +34,7 @@ type State struct {
 	mu                 sync.Mutex
 	provisionResponses map[string]ProvisionResponse
 	statuses           map[string]WarehouseStatus
+	trinoStatuses      map[string]TrinoStatus
 }
 
 func NewExecutor(cfg ExecutorConfig) *Executor {
@@ -51,6 +53,7 @@ func NewState() *State {
 	return &State{
 		provisionResponses: make(map[string]ProvisionResponse),
 		statuses:           make(map[string]WarehouseStatus),
+		trinoStatuses:      make(map[string]TrinoStatus),
 	}
 }
 
@@ -80,6 +83,19 @@ func (s *State) Status(orgID string) (WarehouseStatus, bool) {
 	return status, ok
 }
 
+func (s *State) StoreTrinoStatus(orgID string, status TrinoStatus) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.trinoStatuses[orgID] = status
+}
+
+func (s *State) TrinoStatus(orgID string) (TrinoStatus, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	status, ok := s.trinoStatuses[orgID]
+	return status, ok
+}
+
 func (e *Executor) ExecuteStep(ctx context.Context, step core.Step) error {
 	if e.client == nil {
 		return classified(ErrorClassConfig, fmt.Errorf("provision executor client is required"))
@@ -89,11 +105,30 @@ func (e *Executor) ExecuteStep(ctx context.Context, step core.Step) error {
 		return e.executeProvision(ctx, step)
 	case StepTypeWaitWarehouseReady:
 		return e.executeWaitReady(ctx, step)
+	case StepTypeWaitTrinoReady:
+		return e.executeWaitTrinoReady(ctx, step)
 	case StepTypeDeprovisionWarehouse:
 		return e.executeDeprovision(ctx, step)
 	default:
 		return classified(ErrorClassUnsupportedStep, fmt.Errorf("unsupported provision step type %q", step.Type))
 	}
+}
+
+func (e *Executor) executeWaitTrinoReady(ctx context.Context, step core.Step) error {
+	orgID, err := requiredString(step, "org_id")
+	if err != nil {
+		return err
+	}
+	opts, err := e.waitOptionsForStep(step)
+	if err != nil {
+		return err
+	}
+	status, err := e.client.WaitTrinoReady(ctx, orgID, opts)
+	if err != nil {
+		return err
+	}
+	e.state.StoreTrinoStatus(orgID, status)
+	return nil
 }
 
 func (e *Executor) executeProvision(ctx context.Context, step core.Step) error {

--- a/tests/mw-dev/scenario/provision/steps_test.go
+++ b/tests/mw-dev/scenario/provision/steps_test.go
@@ -305,3 +305,50 @@ func TestExecutorRejectsInvalidWaitOptions(t *testing.T) {
 		t.Fatalf("error class = %q, want %q", classified.ErrorClass(), ErrorClassInvalidStepConfig)
 	}
 }
+
+func TestExecutorWaitTrinoReadyStoresStatusForLaterSteps(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/orgs/scenario-org/trino" {
+			t.Fatalf("path = %s, want org Trino detail path", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"cell":      map[string]any{"id": "cell-001"},
+			"enabled":   true,
+			"available": true,
+			"status": map[string]any{
+				"org":       "scenario-org",
+				"principal": "scenario-db",
+				"catalog":   "org_scenario_db",
+				"cell":      "cell-001",
+				"state":     "ready",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+	state := NewState()
+	executor := NewExecutor(ExecutorConfig{Client: client, State: state})
+	err = executor.ExecuteStep(context.Background(), core.Step{
+		ID:   "wait_trino",
+		Type: StepTypeWaitTrinoReady,
+		With: map[string]any{
+			"org_id":        "scenario-org",
+			"timeout":       "5m",
+			"poll_interval": "5s",
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStep returned error: %v", err)
+	}
+	status, ok := state.TrinoStatus("scenario-org")
+	if !ok || status.Status == nil {
+		t.Fatalf("stored Trino status = %+v, %v; want ready detail", status, ok)
+	}
+	if status.Status.Catalog != "org_scenario_db" {
+		t.Fatalf("stored catalog = %q, want org_scenario_db", status.Status.Catalog)
+	}
+}

--- a/tests/mw-dev/scenario/runner_test.go
+++ b/tests/mw-dev/scenario/runner_test.go
@@ -857,7 +857,7 @@ type dispatchExecutor struct {
 
 func (e dispatchExecutor) ExecuteStep(ctx context.Context, step core.Step) error {
 	switch step.Type {
-	case provision.StepTypeProvisionWarehouse, provision.StepTypeWaitWarehouseReady, provision.StepTypeDeprovisionWarehouse:
+	case provision.StepTypeProvisionWarehouse, provision.StepTypeWaitWarehouseReady, provision.StepTypeWaitTrinoReady, provision.StepTypeDeprovisionWarehouse:
 		return e.provision.ExecuteStep(ctx, step)
 	case scenariosql.StepTypeSQL, scenariosql.StepTypeSQLCatalog:
 		return e.sql.ExecuteStep(ctx, step)
@@ -879,7 +879,7 @@ func (e dispatchExecutor) StepResultMetadata(stepID string) (core.StepResultMeta
 
 func dispatchSupports(stepType string) bool {
 	switch stepType {
-	case provision.StepTypeProvisionWarehouse, provision.StepTypeWaitWarehouseReady, provision.StepTypeDeprovisionWarehouse:
+	case provision.StepTypeProvisionWarehouse, provision.StepTypeWaitWarehouseReady, provision.StepTypeWaitTrinoReady, provision.StepTypeDeprovisionWarehouse:
 		return true
 	case scenariosql.StepTypeSQL, scenariosql.StepTypeSQLCatalog:
 		return true


### PR DESCRIPTION
## Summary

- add a reusable `wait_trino_ready` scenario step backed by the existing org-level Trino admin API
- require Trino to be enabled, reconciled to `ready`, and live-reachable; fail fast on terminal provisioning failures
- retain the resolved Trino identity in scenario state for later workload steps
- preload the Trino association in general admin org reads
- document timeouts, authentication propagation boundaries, and failure recovery

## Tests

- `just test-scenario`
- `just test-unit`
- `just test-controlplane-k8s`
- `just lint`