### PR TITLE
feat(controlplane): expose Trino client connection details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -915,7 +915,9 @@ impersonation, audit log; sliceable by org + user). Design + decisions:
   columns, which were surfaced nowhere before, so a failed Trino provision
   was silent). Read as the OBSERVER principal, never the provisioner's
   admin — see the Trino Cells section and `admin/README.md`. Payloads are
-  redacted (SQL) and projected (never `TrinoEnabledOrg.RootPasswordHash`).
+  redacted (SQL) and projected (never `TrinoEnabledOrg.RootPasswordHash`). A
+  ready, reachable org includes non-secret `status.connection` coordinates;
+  passwords remain write-only provision/reset results.
   Every read is cached + timeout-bounded and degrades to `available:false`
   plus a reason rather than erroring the page: the console must render
   during exactly the incident it exists for. Unset
@@ -1577,6 +1579,12 @@ password/tenant/catalog changes never propagate.
   workers can never authenticate a tenant's metadata store with two different
   credentials. The projection is AUTHORITATIVE, not additive: a disabled org's
   key is removed on the next tick.
+- **Tenant client coordinates are non-secret and readiness-gated.** The org
+  detail endpoint returns `status.connection` only while the catalog is ready
+  and the coordinator is reachable. `DUCKGRES_TRINO_CLIENT_URL` names the HTTPS
+  endpoint clients should dial; when unset, the control plane falls back to its
+  coordinator URL and TLS server name. The response contains host, port and the
+  tenant principal, never a password or password hash.
 - **`Reconcile` order is load-bearing**: cluster secrets → auth files →
   resource groups → OPA bundle → tenant passwords → catalogs, and the
   `globalErr` gate SKIPS the catalog step if any projection failed. A
@@ -1682,12 +1690,8 @@ password/tenant/catalog changes never propagate.
   `trino_cluster_secrets_test.go`, the migration asserts in
   `tests/configstore/migrations_postgres_test.go`, and — for anything the
   admin console reads — `controlplane/admin/trino{,_client}_test.go` plus
-  the `ui/src/lib/trino.test.ts` derivations. **There is no
-  `tests/mw-dev/e2e/harness.sh` coverage yet**, and that is a stated gap, not
-  an oversight: mw-dev runs no Trino cell, so there is nothing for the
-  in-cluster Job to talk to. The harness assertion (enable an org, poll the
-  row to `ready`, query the catalog as the org's `root`) lands with the chart
-  that deploys the cell.
+  the `ui/src/lib/trino.test.ts` derivations and
+  `tests/mw-dev/e2e/trino.sh`.
 
 ## TODO Reference
 

--- a/controlplane/admin/README.md
+++ b/controlplane/admin/README.md
@@ -84,7 +84,7 @@ Added for the console:
 | `POST /api/v1/trino/queries/:id/kill` | admin | fail a query with a reason (`PUT /v1/query/{id}/killed`). The reason reaches the TENANT as the query's error message. Audited as `trino.query.kill` with the owning org |
 | `GET /api/v1/trino/nodes` | viewer | the cell's fleet: `/v1/node` + `/v1/node/failed` where bound, else `/v1/announce` membership; the response names which (`source`) |
 | `GET /api/v1/trino/orgs` | viewer | per-org Trino provisioning state + that org's live query counts |
-| `GET /api/v1/orgs/:id/trino` | viewer | one org's Trino state; `status.trino_catalog_name` is the provisioned catalog identifier, and `enabled:false` represents an org with no Trino row |
+| `GET /api/v1/orgs/:id/trino` | viewer | one org's Trino state; a ready, reachable tenant includes non-secret `status.connection` (`host`, `port`, `username`), `status.trino_catalog_name` is the provisioned catalog identifier, and `enabled:false` represents an org with no Trino row. The tenant password is returned only by provision/reset APIs |
 | `GET /api/v1/audit` | admin | admin action log |
 | `GET /api/v1/operators` | admin | list console operators (email → role) |
 | `POST /api/v1/operators` | admin | add/update an operator (`{email, role}`; last-admin demotion → 409) |

--- a/controlplane/admin/trino.go
+++ b/controlplane/admin/trino.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -46,6 +48,14 @@ type TrinoOrgStore interface {
 type TrinoCell struct {
 	ID             string `json:"id"`
 	CoordinatorURL string `json:"coordinator_url"`
+	TLSServerName  string `json:"-"`
+	ClientURL      string `json:"-"`
+}
+
+type TrinoConnection struct {
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+	Username string `json:"username"`
 }
 
 // TrinoOrgStatus is one org's Trino provisioning state, joined with what
@@ -65,15 +75,46 @@ type TrinoOrgStatus struct {
 	Cell             string `json:"cell"`
 	// State is the most recent reconcile tick's outcome: pending /
 	// provisioning / ready / failed.
-	State         string     `json:"state"`
-	StatusMessage string     `json:"status_message,omitempty"`
-	ReadyAt       *time.Time `json:"ready_at,omitempty"`
-	FailedAt      *time.Time `json:"failed_at,omitempty"`
+	State         string           `json:"state"`
+	StatusMessage string           `json:"status_message,omitempty"`
+	ReadyAt       *time.Time       `json:"ready_at,omitempty"`
+	FailedAt      *time.Time       `json:"failed_at,omitempty"`
+	Connection    *TrinoConnection `json:"connection,omitempty"`
 	// RunningQueries / QueuedQueries are this org's share of the cell right
 	// now. Zero when the coordinator is unreachable — the envelope's
 	// `available` flag is what distinguishes that from a genuinely idle org.
 	RunningQueries int `json:"running_queries"`
 	QueuedQueries  int `json:"queued_queries"`
+}
+
+func (c TrinoCell) connectionFor(username string) *TrinoConnection {
+	if username == "" {
+		return nil
+	}
+
+	clientURL := c.ClientURL
+	if clientURL == "" {
+		clientURL = c.CoordinatorURL
+	}
+	parsedClientURL, err := url.Parse(clientURL)
+	if err != nil || parsedClientURL.Scheme != "https" || parsedClientURL.Hostname() == "" {
+		return nil
+	}
+
+	port := 443
+	if rawPort := parsedClientURL.Port(); rawPort != "" {
+		port, err = strconv.Atoi(rawPort)
+		if err != nil || port < 1 || port > 65535 {
+			return nil
+		}
+	}
+
+	host := parsedClientURL.Hostname()
+	if c.ClientURL == "" && c.TLSServerName != "" {
+		host = c.TLSServerName
+	}
+
+	return &TrinoConnection{Host: host, Port: port, Username: username}
 }
 
 // TrinoStatus is the cluster overview: which cell, whether it answers, what
@@ -611,6 +652,9 @@ func (a *TrinoAPI) handleOrgDetail(c *gin.Context) {
 	status.FailedAt = row.FailedAt
 	status.Tier = row.Tier
 	status.Cell = row.TrinoCellID
+	if available && status.State == string(configstore.ManagedWarehouseStateReady) && status.Cell == a.cell.ID {
+		status.Connection = a.cell.connectionFor(status.Principal)
+	}
 
 	c.JSON(http.StatusOK, gin.H{
 		"cell":      a.cell,

--- a/controlplane/admin/trino_test.go
+++ b/controlplane/admin/trino_test.go
@@ -541,9 +541,58 @@ func TestOrgDetailSurfacesTheReconcileOutcome(t *testing.T) {
 	if st["failed_at"] == nil {
 		t.Error("failed_at must be surfaced")
 	}
+	if _, ok := st["connection"]; ok {
+		t.Error("a failed Trino target must not expose connection details")
+	}
 	// Live counts are scoped to this org only.
 	if st["running_queries"] != float64(1) || st["queued_queries"] != float64(1) {
 		t.Errorf("live counts = %v/%v, want 1 running and 1 queued for org-b", st["running_queries"], st["queued_queries"])
+	}
+}
+
+func TestReadyOrgDetailReturnsTenantClientConnection(t *testing.T) {
+	store := twoOrgTrinoStore()
+	store.rows = map[string]*configstore.ManagedWarehouseTrino{
+		"org-a": {
+			OrgID:       "org-a",
+			Enabled:     true,
+			TrinoCellID: "cell-test",
+			State:       configstore.ManagedWarehouseStateReady,
+		},
+	}
+	api := NewTrinoAPI(
+		TrinoCell{
+			ID:             "cell-test",
+			CoordinatorURL: "https://coordinator.invalid:8443",
+			TLSServerName:  "coordinator.example.com",
+			ClientURL:      "https://trino.example.com:443",
+		},
+		&fakeTrinoCoordinator{},
+		store,
+		nil,
+	)
+	if api == nil {
+		t.Fatal("NewTrinoAPI returned nil for a fully-wired cell")
+	}
+	r := trinoTestRouter(api, RoleViewer)
+
+	code, body := doTrinoJSON(t, r, http.MethodGet, "/api/v1/orgs/org-a/trino", "")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	status := body["status"].(map[string]any)
+	connection := status["connection"].(map[string]any)
+	if connection["host"] != "trino.example.com" {
+		t.Errorf("connection host = %v, want trino.example.com", connection["host"])
+	}
+	if connection["port"] != float64(443) {
+		t.Errorf("connection port = %v, want 443", connection["port"])
+	}
+	if connection["username"] != "db_a" {
+		t.Errorf("connection username = %v, want db_a", connection["username"])
+	}
+	if _, ok := connection["password"]; ok {
+		t.Error("the control plane must not return the tenant password")
 	}
 }
 

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -844,8 +844,15 @@ export interface TrinoOrgStatus {
   status_message?: string;
   ready_at?: string;
   failed_at?: string;
+  connection?: TrinoConnection;
   running_queries: number;
   queued_queries: number;
+}
+
+export interface TrinoConnection {
+  host: string;
+  port: number;
+  username: string;
 }
 
 // available=false means the coordinator could not be read. Every count then

--- a/controlplane/trino_inputs.go
+++ b/controlplane/trino_inputs.go
@@ -74,6 +74,11 @@ const (
 	// http, so https is effectively required for the provisioner to authenticate.
 	envTrinoCoordinatorServerName = "DUCKGRES_TRINO_COORDINATOR_SERVER_NAME"
 
+	// envTrinoClientURL is the HTTPS endpoint tenant clients should dial.
+	// Empty falls back to the coordinator URL, with its TLS server name used
+	// as the host when configured.
+	envTrinoClientURL = "DUCKGRES_TRINO_CLIENT_URL"
+
 	// envTrinoCellID names the Trino cell this control plane reconciles.
 	// Empty == configstore.DefaultTrinoCellID. The provisioner claims
 	// unassigned Trino-enabled orgs into this cell and ignores orgs
@@ -136,6 +141,7 @@ type trinoCell struct {
 	ID             string
 	CoordinatorURL string
 	TLSServerName  string
+	ClientURL      string
 }
 
 // resolveTrinoCell reads the single cell's configuration from the
@@ -154,6 +160,7 @@ func resolveTrinoCell() (trinoCell, error) {
 		ID:             cellID,
 		CoordinatorURL: coordinatorURL,
 		TLSServerName:  strings.TrimSpace(os.Getenv(envTrinoCoordinatorServerName)),
+		ClientURL:      strings.TrimSpace(os.Getenv(envTrinoClientURL)),
 	}, nil
 }
 
@@ -305,7 +312,12 @@ func buildTrinoWiring(
 		BundleHandler: bundleHandler,
 		Cell:          cell,
 		Console: &trinoConsoleWiring{
-			Cell: admin.TrinoCell{ID: cell.ID, CoordinatorURL: cell.CoordinatorURL},
+			Cell: admin.TrinoCell{
+				ID:             cell.ID,
+				CoordinatorURL: cell.CoordinatorURL,
+				TLSServerName:  cell.TLSServerName,
+				ClientURL:      cell.ClientURL,
+			},
 			// Read the credential through the provisioner on every call
 			// rather than capturing it here: the pair is regenerated if it
 			// ever goes missing, and a captured copy would 401 forever

--- a/tests/mw-dev/e2e/trino.sh
+++ b/tests/mw-dev/e2e/trino.sh
@@ -10,7 +10,7 @@ SECRET="${INTERNAL_SECRET:?}"
 PR="${PR_NUMBER:?}"
 NS="${NAMESPACE:?}"
 H="X-Duckgres-Internal-Secret: $SECRET"
-TRINO="https://duckgres-trino.$NS.svc:8443"
+TRINO=""
 CA=/trino-ca/ca.crt
 ORG_A="ci-pr-${PR}-trinoa"
 ORG_B="ci-pr-${PR}-trinob"
@@ -94,9 +94,10 @@ wait_trino() { # org expected-principal expected-catalog
     body="$(api "$API/api/v1/orgs/$1/trino" 2>/dev/null || true)"
     state="$(printf %s "$body" | jq -r '.status.state // empty' 2>/dev/null || true)"
     if [ "$state" = ready ]; then
-      printf %s "$body" | jq -e --arg p "$2" --arg c "$3" --arg cell "ci-pr-$PR" \
-        '.enabled == true and .status.principal == $p and .status.catalog == $c and .status.cell == $cell and .status.tier == "free"' >/dev/null \
+      printf %s "$body" | jq -e --arg p "$2" --arg c "$3" --arg cell "ci-pr-$PR" --arg host "duckgres-trino.$NS.svc" \
+        '.enabled == true and .available == true and .status.principal == $p and .status.catalog == $c and .status.cell == $cell and .status.tier == "free" and .status.connection.host == $host and .status.connection.port == 8443 and .status.connection.username == $p and (.status.connection | has("password") | not)' >/dev/null \
         || fail "$1 Trino status identity mismatch: $body"
+      TRINO="https://$(printf %s "$body" | jq -r '.status.connection.host'):$(printf %s "$body" | jq -r '.status.connection.port')"
       return 0
     fi
     [ "$state" = failed ] && fail "$1 Trino provisioning failed: $body"

--- a/tests/mw-dev/trino-controlplane-patch.tmpl.json
+++ b/tests/mw-dev/trino-controlplane-patch.tmpl.json
@@ -15,6 +15,10 @@
                 "value": "duckgres-trino.${NAMESPACE}.svc"
               },
               {
+                "name": "DUCKGRES_TRINO_CLIENT_URL",
+                "value": "https://duckgres-trino.${NAMESPACE}.svc:8443"
+              },
+              {
                 "name": "DUCKGRES_TRINO_NAMESPACE",
                 "value": "${NAMESPACE}"
               },


### PR DESCRIPTION
## Summary

- Ready, reachable Trino tenants now expose host, port, and username through the org detail endpoint.
- Connection details appear only when the tenant belongs to the serving cell.
- The API never returns the tenant password or its stored hash.
- `DUCKGRES_TRINO_CLIENT_URL` can separate the tenant endpoint from the control plane's coordinator endpoint.
- The mw-dev Trino lane now connects through the returned coordinates instead of a hardcoded URL.

## Testing

- `just lint`
- Focused Trino control-plane API tests
- Kubernetes control-plane compile check
- Admin UI typecheck, targeted Trino tests, and production build
- Shell syntax and JSON template validation

## Related

- Supports PostHog/posthog#92846.
