### PR TITLE
Match Trino perf worker compute to Duckgres

### DIFF
--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -121,7 +121,7 @@ Pod Identity associations.
 ## Isolated Trino lane
 
 The Trino lane never uses the shared mw-dev Trino namespace or coordinator.
-It deploys one coordinator, one worker, and an OPA sidecar in the lane's
+It deploys one coordinator, two workers, and an OPA sidecar in the lane's
 `duckgres-ci-pr-<N>` namespace. The control plane projects fixed-name auth,
 tenant-secret, OPA-token, and resource-group objects into that same namespace;
 its cell id and PostgreSQL catalog store are also PR-local. This isolation is
@@ -132,6 +132,12 @@ The lane defaults `TRINO_IMAGE` to the pinned PostHog fork used when this suite
 was added. That fork contains the DuckLake connector and PostgreSQL dynamic
 catalog store; upstream `trinodb/trino` is not compatible. Update the default
 in `run.sh` and `e2e-mw-dev.yml` together when promoting a Trino build.
+Each Trino worker has requests and limits of 1 CPU and 4Gi. Together they match
+the frozen perf Duckgres worker's aggregate 2 CPU and 8Gi execution budget while
+exercising Trino's distributed execution path. Trino permits 2GB of query
+memory per worker and 4GB cluster-wide. The coordinator does not execute query
+tasks (`node-scheduler.include-coordinator=false`) and is additional Trino
+control-plane overhead rather than part of the matched execution budget.
 `TRINO_TLS_PASSWORD` defaults to `duckgres-e2e-keystore`; it protects only the
 random, two-day, per-run PKCS12 file. `run.sh` generates a fresh CA and leaf
 certificate under `DUCKGRES_CI_SECRET_DIR`, mounts the CA into the PR control

--- a/tests/mw-dev/manifests.trino.tmpl.yaml
+++ b/tests/mw-dev/manifests.trino.tmpl.yaml
@@ -52,7 +52,9 @@ data:
     http-server.https.keystore.path=/etc/trino/tls/keystore.p12
     http-server.https.keystore.key=${ENV:TRINO_TLS_KEYSTORE_PASSWORD}
     discovery.uri=http://duckgres-trino.${NAMESPACE}.svc:8080
-    query.max-memory=2GB
+    query.max-memory=4GB
+    # The coordinator does not execute tasks and retains headroom in its 2G
+    # heap; execution workers carry the 2GB per-node allowance below.
     query.max-memory-per-node=1GB
     catalog.management=dynamic
     catalog.store=posthog
@@ -100,8 +102,8 @@ data:
     coordinator=false
     http-server.http.port=8080
     discovery.uri=http://duckgres-trino.${NAMESPACE}.svc:8080
-    query.max-memory=2GB
-    query.max-memory-per-node=1GB
+    query.max-memory=4GB
+    query.max-memory-per-node=2GB
     shutdown.grace-period=10s
     catalog.management=dynamic
     internal-communication.shared-secret=${ENV:TRINO_INTERNAL_COMMUNICATION_SHARED_SECRET}
@@ -260,7 +262,10 @@ spec:
             periodSeconds: 5
           resources:
             requests: { cpu: "1", memory: 4Gi }
-            limits: { cpu: "2", memory: 4Gi }
+            # Two replicas provide the same aggregate 2-CPU/8Gi execution
+            # budget as the frozen-perf Duckgres worker. Keep requests equal
+            # to limits so node contention cannot change the comparison.
+            limits: { cpu: "1", memory: 4Gi }
           volumeMounts:
             - { name: config, mountPath: /etc/trino/node.properties, subPath: node.properties }
             - { name: config, mountPath: /etc/trino/jvm.config, subPath: jvm.config }

--- a/tests/mw-dev/run.sh
+++ b/tests/mw-dev/run.sh
@@ -346,10 +346,12 @@ cmd_deploy() {
     # Patch the Deployment resources directly. The CI deployer intentionally
     # cannot patch the deployments/scale subresource, while it already needs
     # narrowly scoped Deployment patch access for the control-plane config.
-    for deployment in duckgres-trino-coordinator duckgres-trino-worker; do
-      "${KUBECTL[@]}" -n "$NS" patch deployment "$deployment" \
-        --type=merge -p '{"spec":{"replicas":1}}'
-    done
+    # Two 1-CPU/4Gi workers match the frozen-perf Duckgres worker's aggregate
+    # 2-CPU/8Gi execution budget while exercising Trino's distributed path.
+    "${KUBECTL[@]}" -n "$NS" patch deployment duckgres-trino-coordinator \
+      --type=merge -p '{"spec":{"replicas":1}}'
+    "${KUBECTL[@]}" -n "$NS" patch deployment duckgres-trino-worker \
+      --type=merge -p '{"spec":{"replicas":2}}'
     "${KUBECTL[@]}" -n "$NS" rollout status deploy/duckgres-trino-coordinator --timeout=300s
     "${KUBECTL[@]}" -n "$NS" rollout status deploy/duckgres-trino-worker --timeout=300s
   fi

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -124,10 +124,82 @@ func TestTrinoDeployStartsWorkloadsWithoutScaleSubresource(t *testing.T) {
 	if strings.Contains(calls, " scale ") {
 		t.Fatalf("Trino deploy requires deployments/scale RBAC; calls:\n%s", calls)
 	}
-	for _, deployment := range []string{"duckgres-trino-coordinator", "duckgres-trino-worker"} {
-		want := "patch deployment " + deployment + " --type=merge -p {\"spec\":{\"replicas\":1}}"
+	for deployment, replicas := range map[string]int{
+		"duckgres-trino-coordinator": 1,
+		"duckgres-trino-worker":      2,
+	} {
+		want := "patch deployment " + deployment + " --type=merge -p {\"spec\":{\"replicas\":" + strconv.Itoa(replicas) + "}}"
 		if !strings.Contains(calls, want) {
-			t.Errorf("Trino deploy did not start %s through the deployment resource; calls:\n%s", deployment, calls)
+			t.Errorf("Trino deploy did not start %s with %d replicas through the deployment resource; calls:\n%s", deployment, replicas, calls)
+		}
+	}
+}
+
+func TestTrinoWorkersMatchDuckgresAggregateCompute(t *testing.T) {
+	raw, err := os.ReadFile("manifests.trino.tmpl.yaml")
+	if err != nil {
+		t.Fatalf("read Trino manifests template: %v", err)
+	}
+	rendered := strings.NewReplacer(
+		"${NAMESPACE}", "test-namespace",
+		"${PR_NUMBER}", "123",
+		"${TRINO_IMAGE}", "example.invalid/trino:test",
+		"${TRINO_TLS_PASSWORD}", "test-password",
+		"${TRINO_CA_CERT_B64}", "dGVzdA==",
+		"${TRINO_SERVER_P12_B64}", "dGVzdA==",
+	).Replace(string(raw))
+
+	decoder := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(rendered), 4096)
+	var workerDeployment, coordinatorConfig, workerConfig map[string]any
+	for {
+		var manifest map[string]any
+		err := decoder.Decode(&manifest)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("decode Trino manifests template: %v", err)
+		}
+		switch {
+		case manifest["kind"] == "Deployment" && manifestName(manifest) == "duckgres-trino-worker":
+			workerDeployment = manifest
+		case manifest["kind"] == "ConfigMap" && manifestName(manifest) == "duckgres-trino-coordinator":
+			coordinatorConfig = manifest
+		case manifest["kind"] == "ConfigMap" && manifestName(manifest) == "duckgres-trino-worker":
+			workerConfig = manifest
+		}
+	}
+	if workerDeployment == nil || coordinatorConfig == nil || workerConfig == nil {
+		t.Fatalf("missing Trino manifests: worker deployment=%t coordinator config=%t worker config=%t", workerDeployment != nil, coordinatorConfig != nil, workerConfig != nil)
+	}
+
+	spec := workerDeployment["spec"].(map[string]any)
+	template := spec["template"].(map[string]any)
+	podSpec := template["spec"].(map[string]any)
+	containers := podSpec["containers"].([]any)
+	worker := containers[0].(map[string]any)
+	resources := worker["resources"].(map[string]any)
+	for _, field := range []string{"requests", "limits"} {
+		values := resources[field].(map[string]any)
+		if values["cpu"] != "1" || values["memory"] != "4Gi" {
+			t.Errorf("Trino worker %s = %v, want 1 CPU and 4Gi", field, values)
+		}
+	}
+
+	for name, expectedPerNode := range map[string]string{
+		"coordinator": "1GB",
+		"worker":      "2GB",
+	} {
+		manifest := coordinatorConfig
+		if name == "worker" {
+			manifest = workerConfig
+		}
+		data := manifest["data"].(map[string]any)
+		config := data["config.properties"].(string)
+		for _, want := range []string{"query.max-memory=4GB", "query.max-memory-per-node=" + expectedPerNode} {
+			if !strings.Contains(config, want) {
+				t.Errorf("Trino %s config missing %q:\n%s", name, want, config)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- run isolated Trino with two 1 CPU / 4Gi workers
- keep aggregate Trino execution resources equal to the frozen-perf Duckgres worker
- increase Trino query memory to 2GB per worker and 4GB cluster-wide
- document the benchmark resource model and keep the coordinator out of query execution

## Tests
- `go test -count=1 ./tests/mw-dev/scenario ./tests/mw-dev ./tests/perf/publishercli`
- `just lint`