### PR TITLE
fix(server): raise the default control-plane idle timeout to 15m

### DIFF
--- a/server/exports.go
+++ b/server/exports.go
@@ -94,12 +94,26 @@ func NewClientConn(s *Server, conn net.Conn, reader *bufio.Reader, writer *bufio
 // connection rather than an idle one — and a client cannot safely replay a
 // write that may already have committed, so the failure reaches the user.
 //
-// 5m keeps the reclaim bounded while covering the gaps a batch or BI client
-// leaves between statements. Deployments that want tighter worker density set
-// --idle-timeout / DUCKGRES_IDLE_TIMEOUT; a client that needs longer asks for
-// it per connection with duckgres.idle_timeout, bounded by
-// DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX.
-const DefaultControlPlaneIdleTimeout = 5 * time.Minute
+// 5m fixed the worst of that but still sat inside the gaps clients actually
+// leave. Measured over a production deployment, the connections it reaped were
+// not abandoned: the client came back a median of 8s after the reap and at
+// worst 58s, so every observed idle gap fell between 5m00s and 5m58s. Those
+// clients were missing the threshold by seconds and paying a cold worker
+// respawn to get back, which is churn with no reclaim benefit — and only ~4%
+// of reaps had no client return at all, so a longer window is not exposing
+// many genuinely abandoned connections.
+//
+// 15m clears that cluster with margin for a slower run, and costs on the order
+// of one continuously-held worker across the fleet. It is deliberately at the
+// ceiling the accompanying test enforces: past this, an abandoned connection
+// holds a pinned worker too long to justify by default. Deployments that want
+// tighter worker density set --idle-timeout / DUCKGRES_IDLE_TIMEOUT; a client
+// that needs longer asks for it per connection with duckgres.idle_timeout,
+// bounded by DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX.
+//
+// This is a frequency reduction, not a correctness fix: a client whose gap can
+// exceed any finite timeout still needs to treat the reap as retryable.
+const DefaultControlPlaneIdleTimeout = 15 * time.Minute
 
 // NormalizeIdleTimeout resolves a configured connection idle timeout: zero means
 // "unset" → use zeroDefault; a negative value means "explicitly disabled" → 0

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -44,9 +44,14 @@ func TestCancelQueryDoesNotLogSecretKey(t *testing.T) {
 // The floor is what matters here. Anything at or below a minute reintroduces
 // that failure; the exact value above it is a density trade-off operators can
 // make with --idle-timeout.
+//
+// 5m was still short of the gaps clients leave in practice: measured in
+// production, reaped connections came back a median of 8s (worst 58s) after
+// the reap, so the reaps were hitting clients that missed the threshold by
+// seconds and then paid a cold respawn. 15m clears that with margin.
 func TestDefaultControlPlaneIdleTimeout(t *testing.T) {
-	if DefaultControlPlaneIdleTimeout != 5*time.Minute {
-		t.Errorf("DefaultControlPlaneIdleTimeout = %v, want 5m", DefaultControlPlaneIdleTimeout)
+	if DefaultControlPlaneIdleTimeout != 15*time.Minute {
+		t.Errorf("DefaultControlPlaneIdleTimeout = %v, want 15m", DefaultControlPlaneIdleTimeout)
 	}
 	// A client that pauses between statements must survive the pause.
 	if DefaultControlPlaneIdleTimeout <= time.Minute {


### PR DESCRIPTION
## Why

An idle client connection pins a worker, so the control plane closes it after `DefaultControlPlaneIdleTimeout`. That was 60s (broke any client pausing between statements), then 5m. **5m is still short of the gaps clients actually leave.**

Measured against a production deployment, the connections 5m was reaping were *not* abandoned:

```
reap -> client's next use:   p50 8s    p90 35s    max 58s
```

Every observed idle gap fell between **5m00s and 5m58s**. These clients were missing the threshold by seconds, then paying a cold worker respawn to get back — churn that reclaims nothing. And only ~4% of reaps had no client return at all, so the window isn't holding many genuinely abandoned connections either.

There's a prior data point for the lever working: reaps ran ~850/day at 60s and dropped to ~170/day at 5m.

## What

`DefaultControlPlaneIdleTimeout` 5m → 15m.

| | reaps avoided | extra idle worker time |
|---|---|---|
| 10m | 100% of measured | ~0.5 workers held |
| **15m** | 100% + margin | **~1.1 workers held** |

10m would clear the measured cluster, but the worst observed gap is already 5m58s — that leaves ~4 minutes before a slower run puts us back here. 15m buys real margin for about one continuously-held worker fleet-wide, against roughly 150 avoided cold restarts a day.

The value deliberately sits **at** the ceiling `TestDefaultControlPlaneIdleTimeout` enforces: beyond 15m an abandoned connection holds a pinned worker too long to justify as a default. Raising it further should be a deliberate decision that trips that guard.

Escape hatches are unchanged: operators wanting tighter density set `--idle-timeout` / `DUCKGRES_IDLE_TIMEOUT`; a client needing longer asks per connection via `duckgres.idle_timeout`, bounded by `DUCKGRES_CLIENT_IDLE_TIMEOUT_MAX`.

## Scope

This reduces how often the reap fires — **it is not a correctness fix.** A client whose gap can exceed any finite timeout still has to treat the reap as retryable rather than fatal. Clients that already request a longer per-connection `duckgres.idle_timeout` are unaffected.

## Testing

- `go build ./...` and `go vet ./...` clean.
- `./server/...` green, including the updated `TestDefaultControlPlaneIdleTimeout`.
- `go test ./...` has 4 failing packages (`cmd/cache-proxy`, `tests/controlplane`, `tests/integration`, `tests/trino-ducklake-smoke`) — verified **identical on unmodified `origin/main`** in this environment, so they're pre-existing/environmental (they need docker/postgres/trino), not introduced here.
