### PR TITLE
test(perf): increase Trino worker execution concurrency

### DIFF
--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -176,7 +176,7 @@ gh workflow run scenario-dev.yml --ref <branch> -f scenario=posthog_frozen_perf
 Compare per-query Trino medians against the prior baseline, checking for query
 errors, worker restarts, CPU throttling, and memory pressure. Higher concurrency
 can increase heap usage and context switching. If it regresses, remove the two
-worker properties in `manifests.trino.tmpl.yaml` (and update their test assertions)
+worker properties in `manifests.trino.tmpl.yaml`
 to restore CPU-derived defaults, then rerun in a fresh isolated deployment.
 Do not patch a running benchmark; let workflow teardown clean up its stack.
 

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -156,6 +156,30 @@ of query memory per worker and 6GB cluster-wide. The coordinator does not
 execute query tasks (`node-scheduler.include-coordinator=false`) and is
 additional Trino control-plane overhead rather than part of the matched
 execution budget.
+
+The isolated lane explicitly sets `task.max-worker-threads=8` and
+`task.min-drivers=16` per worker, four times the pinned engine's expected
+one-CPU defaults of 2 and 4. The latter is a leaf-driver target, not a hard
+limit or a count of simultaneous storage requests. These settings apply to
+both the isolated Trino E2E suite and `posthog_frozen_perf`; they do not change
+shared or production deployments. Worker resources, 3G heaps, query-memory
+limits, coordinator configuration, and aggregation `task.concurrency` remain
+unchanged. This tests whether more overlapping scan work improves throughput
+when the existing CPU budget is underused; it is not a proven speedup.
+
+To validate a branch against the existing frozen benchmark:
+
+```bash
+gh workflow run scenario-dev.yml --ref <branch> -f scenario=posthog_frozen_perf
+```
+
+Compare per-query Trino medians against the prior baseline, checking for query
+errors, worker restarts, CPU throttling, and memory pressure. Higher concurrency
+can increase heap usage and context switching. If it regresses, remove the two
+worker properties in `manifests.trino.tmpl.yaml` (and update their test assertions)
+to restore CPU-derived defaults, then rerun in a fresh isolated deployment.
+Do not patch a running benchmark; let workflow teardown clean up its stack.
+
 `TRINO_TLS_PASSWORD` defaults to `duckgres-e2e-keystore`; it protects only the
 random, two-day, per-run PKCS12 file. `run.sh` generates a fresh CA and leaf
 certificate under `DUCKGRES_CI_SECRET_DIR`, mounts the CA into the PR control

--- a/tests/mw-dev/manifests.trino.tmpl.yaml
+++ b/tests/mw-dev/manifests.trino.tmpl.yaml
@@ -104,6 +104,10 @@ data:
     discovery.uri=http://duckgres-trino.${NAMESPACE}.svc:8080
     query.max-memory=6GB
     query.max-memory-per-node=2GB
+    # Overlap scan work at the existing CPU/memory budget: 4x the expected
+    # one-CPU defaults (2 threads / 4 leaf drivers). Keep task.concurrency default.
+    task.max-worker-threads=8
+    task.min-drivers=16
     shutdown.grace-period=10s
     catalog.management=dynamic
     internal-communication.shared-secret=${ENV:TRINO_INTERNAL_COMMUNICATION_SHARED_SECRET}

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -207,6 +207,23 @@ func TestTrinoWorkersMatchDuckgresAggregateCompute(t *testing.T) {
 		}
 	}
 	workerData := workerConfig["data"].(map[string]any)
+	workerProperties := workerData["config.properties"].(string)
+	for _, want := range []string{"task.max-worker-threads=8", "task.min-drivers=16"} {
+		if !strings.Contains("\n"+workerProperties, "\n"+want+"\n") {
+			t.Errorf("Trino worker config missing explicit concurrency setting %q:\n%s", want, workerProperties)
+		}
+	}
+	coordinatorProperties := coordinatorConfig["data"].(map[string]any)["config.properties"].(string)
+	for _, key := range []string{"task.max-worker-threads=", "task.min-drivers="} {
+		if strings.Contains(coordinatorProperties, key) {
+			t.Errorf("worker concurrency setting %q must not change coordinator config", key)
+		}
+	}
+	for name, config := range map[string]string{"worker": workerProperties, "coordinator": coordinatorProperties} {
+		if strings.Contains(config, "task.concurrency=") {
+			t.Errorf("Trino %s must retain default aggregation concurrency", name)
+		}
+	}
 	if jvmConfig := workerData["jvm.config"].(string); !strings.Contains(jvmConfig, "-Xmx3G") {
 		t.Errorf("Trino worker JVM config does not fit its 4Gi pod:\n%s", jvmConfig)
 	}

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -207,23 +207,6 @@ func TestTrinoWorkersMatchDuckgresAggregateCompute(t *testing.T) {
 		}
 	}
 	workerData := workerConfig["data"].(map[string]any)
-	workerProperties := workerData["config.properties"].(string)
-	for _, want := range []string{"task.max-worker-threads=8", "task.min-drivers=16"} {
-		if !strings.Contains("\n"+workerProperties, "\n"+want+"\n") {
-			t.Errorf("Trino worker config missing explicit concurrency setting %q:\n%s", want, workerProperties)
-		}
-	}
-	coordinatorProperties := coordinatorConfig["data"].(map[string]any)["config.properties"].(string)
-	for _, key := range []string{"task.max-worker-threads=", "task.min-drivers="} {
-		if strings.Contains(coordinatorProperties, key) {
-			t.Errorf("worker concurrency setting %q must not change coordinator config", key)
-		}
-	}
-	for name, config := range map[string]string{"worker": workerProperties, "coordinator": coordinatorProperties} {
-		if strings.Contains(config, "task.concurrency=") {
-			t.Errorf("Trino %s must retain default aggregation concurrency", name)
-		}
-	}
 	if jvmConfig := workerData["jvm.config"].(string); !strings.Contains(jvmConfig, "-Xmx3G") {
 		t.Errorf("Trino worker JVM config does not fit its 4Gi pod:\n%s", jvmConfig)
 	}


### PR DESCRIPTION
## Summary

Follow up on the completed experiment in #1162, closed without merging its shape-selection code. Start from `main` and change only the isolated Trino test lane's worker execution concurrency:

- Set `task.max-worker-threads=8` and `task.min-drivers=16` per worker, 4x the pinned engine's expected one-CPU defaults of 2 and 4.
- Keep three 1-CPU/4-GiB workers, 3G heaps, query-memory limits, coordinator configuration, and aggregation `task.concurrency` unchanged.
- Preserve the existing SQL, cache settings, warmups, and measured iterations. No matrix, new profiles, or workflow changes.
- Document scope, benchmark dispatch, tradeoffs, and recovery. No test changes.

The shared isolated manifest is used by both Trino E2E and frozen perf. Shared and production deployments are unaffected.

## Motivation

The [four-shape benchmark](https://github.com/PostHog/duckgres/actions/runs/34245776000) showed little benefit from consolidation at equal resources and approximately 2x throughput at twice the worker budget. Historical CPU usage during exact distinct was around 48-56% of quota. The experiment increased both resources and CPU-derived concurrency, so it did not isolate a CPU or storage bottleneck.

This change tests whether additional overlapping scan work improves latency at the original resource budget. `task.min-drivers` is a leaf-driver target, not a hard limit or an S3 request count. Higher concurrency can also increase heap pressure and context switching; no performance improvement is claimed before validation.

## Validation

- `go test -count=1 ./tests/mw-dev ./tests/perf/publishercli` passed.
- `just test-scenario` passed.
- `git diff --check` passed; independent review found no actionable issues.
- `just lint` reports six existing SA4023 diagnostics in unchanged control-plane code; reproduced on base `d7e852d8`. Changed-code lint (`golangci-lint run --new-from-rev=origin/main`) passed.

Run the existing benchmark on this branch and compare query medians, errors, memory pressure, and CPU behavior against the recorded baseline before merging:

```bash
gh workflow run scenario-dev.yml --ref codex/trino-perf-read-concurrency -f scenario=posthog_frozen_perf
```
