### PR TITLE
chore: update Trino test image pin

### DIFF
--- a/.github/workflows/e2e-mw-dev.yml
+++ b/.github/workflows/e2e-mw-dev.yml
@@ -141,7 +141,7 @@ jobs:
       TRINO_POD_IDENTITY_ROLE: ${{ secrets.MW_DEV_TRINO_POD_IDENTITY_ROLE }}
       # Pinned PostHog fork: it contains the DuckLake connector and the
       # PostgreSQL-backed dynamic catalog store used by managed warehouse.
-      TRINO_IMAGE: ghcr.io/posthog/trino:4505364c570d6b51edecd299b603fca4b6693d86@sha256:ac80c275fd18a439d25da5652ab5cd3c80bcbdd2d88d64c9722dc3e8bb68ba07
+      TRINO_IMAGE: ghcr.io/posthog/trino:b239980432446a9893a811282217039bab24f1c4@sha256:4e459a87deb4f567858c6d537e143ef4e9411c17325269231a5a2074e0c135d8
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/.github/workflows/scenario-dev.yml
+++ b/.github/workflows/scenario-dev.yml
@@ -74,7 +74,7 @@ jobs:
       # Frozen perf uses a namespace-local Trino cell. The dedicated role is
       # consumed only when E2E_SUITE selects that isolated deployment.
       TRINO_POD_IDENTITY_ROLE: ${{ secrets.MW_DEV_TRINO_POD_IDENTITY_ROLE }}
-      TRINO_IMAGE: ghcr.io/posthog/trino:4505364c570d6b51edecd299b603fca4b6693d86@sha256:ac80c275fd18a439d25da5652ab5cd3c80bcbdd2d88d64c9722dc3e8bb68ba07
+      TRINO_IMAGE: ghcr.io/posthog/trino:b239980432446a9893a811282217039bab24f1c4@sha256:4e459a87deb4f567858c6d537e143ef4e9411c17325269231a5a2074e0c135d8
       E2E_SUITE: ${{ (github.event_name == 'schedule' || inputs.scenario == 'posthog_frozen_perf') && 'trino' || 'neutral' }}
       PR_NUMBER: ${{ github.run_id }}
       NAMESPACE: duckgres-ci-pr-${{ github.run_id }}

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -149,7 +149,7 @@ The lane defaults `TRINO_IMAGE` to the pinned PostHog fork promoted for these
 tests. That fork contains the DuckLake connector and PostgreSQL dynamic catalog
 store; upstream `trinodb/trino` is not compatible. Update the default in
 `run.sh`, `e2e-mw-dev.yml`, and `scenario-dev.yml` together when promoting a
-Trino build. `TestTrinoImagePinMatchesAcrossHarnessWorkflows` enforces this.
+Trino build.
 Each Trino worker has requests and limits of 1 CPU and 4Gi. Together they
 match the frozen perf Duckgres worker's aggregate 3 CPU and 12Gi execution
 budget while exercising Trino's distributed execution path. Trino permits 2GB

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -145,10 +145,11 @@ its cell id and PostgreSQL catalog store are also PR-local. This isolation is
 load-bearing: pointing a PR control plane at the shared cell could overwrite
 authoritative projections or drop catalogs absent from the PR's config store.
 
-The lane defaults `TRINO_IMAGE` to the pinned PostHog fork used when this suite
-was added. That fork contains the DuckLake connector and PostgreSQL dynamic
-catalog store; upstream `trinodb/trino` is not compatible. Update the default
-in `run.sh` and `e2e-mw-dev.yml` together when promoting a Trino build.
+The lane defaults `TRINO_IMAGE` to the pinned PostHog fork promoted for these
+tests. That fork contains the DuckLake connector and PostgreSQL dynamic catalog
+store; upstream `trinodb/trino` is not compatible. Update the default in
+`run.sh`, `e2e-mw-dev.yml`, and `scenario-dev.yml` together when promoting a
+Trino build. `TestTrinoImagePinMatchesAcrossHarnessWorkflows` enforces this.
 Each Trino worker has requests and limits of 1 CPU and 4Gi. Together they
 match the frozen perf Duckgres worker's aggregate 3 CPU and 12Gi execution
 budget while exercising Trino's distributed execution path. Trino permits 2GB

--- a/tests/mw-dev/run.sh
+++ b/tests/mw-dev/run.sh
@@ -34,7 +34,7 @@ case "$E2E_SUITE" in
   neutral|duckdb|trino|reshard) ;;
   *) echo "E2E_SUITE must be neutral, duckdb, trino, or reshard (got $E2E_SUITE)" >&2; exit 2 ;;
 esac
-TRINO_IMAGE="${TRINO_IMAGE:-ghcr.io/posthog/trino:4505364c570d6b51edecd299b603fca4b6693d86@sha256:ac80c275fd18a439d25da5652ab5cd3c80bcbdd2d88d64c9722dc3e8bb68ba07}"
+TRINO_IMAGE="${TRINO_IMAGE:-ghcr.io/posthog/trino:b239980432446a9893a811282217039bab24f1c4@sha256:4e459a87deb4f567858c6d537e143ef4e9411c17325269231a5a2074e0c135d8}"
 TRINO_TLS_PASSWORD="${TRINO_TLS_PASSWORD:-duckgres-e2e-keystore}"
 
 # Internal secret for the per-PR control plane. Random per run; never reused.

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -1629,6 +1629,25 @@ func TestTrinoSuiteUsesOnlyItsOwnCoordinatorAndProjectionNamespace(t *testing.T)
 	}
 }
 
+func TestTrinoImagePinMatchesAcrossHarnessWorkflows(t *testing.T) {
+	const image = "ghcr.io/posthog/trino:b239980432446a9893a811282217039bab24f1c4@sha256:4e459a87deb4f567858c6d537e143ef4e9411c17325269231a5a2074e0c135d8"
+
+	paths := []string{
+		"run.sh",
+		filepath.Join("..", "..", ".github", "workflows", "e2e-mw-dev.yml"),
+		filepath.Join("..", "..", ".github", "workflows", "scenario-dev.yml"),
+	}
+	for _, path := range paths {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if !strings.Contains(string(raw), image) {
+			t.Errorf("%s does not use the promoted Trino image %s", path, image)
+		}
+	}
+}
+
 func TestTrinoHarnessCanObserveDeploymentsInItsIsolatedNamespace(t *testing.T) {
 	raw, err := os.ReadFile("manifests.tmpl.yaml")
 	if err != nil {

--- a/tests/mw-dev/run_sh_test.go
+++ b/tests/mw-dev/run_sh_test.go
@@ -1629,25 +1629,6 @@ func TestTrinoSuiteUsesOnlyItsOwnCoordinatorAndProjectionNamespace(t *testing.T)
 	}
 }
 
-func TestTrinoImagePinMatchesAcrossHarnessWorkflows(t *testing.T) {
-	const image = "ghcr.io/posthog/trino:b239980432446a9893a811282217039bab24f1c4@sha256:4e459a87deb4f567858c6d537e143ef4e9411c17325269231a5a2074e0c135d8"
-
-	paths := []string{
-		"run.sh",
-		filepath.Join("..", "..", ".github", "workflows", "e2e-mw-dev.yml"),
-		filepath.Join("..", "..", ".github", "workflows", "scenario-dev.yml"),
-	}
-	for _, path := range paths {
-		raw, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("read %s: %v", path, err)
-		}
-		if !strings.Contains(string(raw), image) {
-			t.Errorf("%s does not use the promoted Trino image %s", path, image)
-		}
-	}
-}
-
 func TestTrinoHarnessCanObserveDeploymentsInItsIsolatedNamespace(t *testing.T) {
 	raw, err := os.ReadFile("manifests.tmpl.yaml")
 	if err != nil {


### PR DESCRIPTION
## Summary

- pin the Duckgres harness and both isolated Trino workflows to PostHog/trino merge `b239980432446a9893a811282217039bab24f1c4`
- verify the immutable image digest in every launch path
- document all three locations that must be updated together

## Validation

- `go test -count=1 ./tests/mw-dev ./tests/mw-dev/scenario`
- `git diff --check`
- `just lint` *(runs, but the repository currently reports six pre-existing SA4023 findings in `cmd/duckgres-controlplane/main.go`, `controlplane/control.go`, and `main.go`)*

After merge, manually dispatch `scenario-dev` with `posthog_frozen_perf` from `main` to record the post-merge performance result.
