### PR TITLE
feat(trino): capture query usage analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,8 +581,8 @@ teardown), so you can build a provisioning funnel and alert on failures.
 | `warehouse_deprovision_failed` | A teardown attempt failed (provisioner controller) | `reason` (`duckling_delete_failed`) |
 | `warehouse_password_reset` | An org's root password is reset (admin API) | `username` |
 | `query_initiated` | An accepted, non-empty client query is received | `user`, `team_id`, `trace_id`, `application_name` |
-| `query_completed` | A statement finishes executing successfully | `user`, `team_id`, `trace_id`, `protocol`, `query_kind`, `duration_ms`, `cpu_seconds` (DuckDB CPU/thread-time), `result_rows`, `application_name` |
-| `query_failed` | A query errors | `user`, `team_id`, `trace_id`, `error_code` (SQLSTATE), `error_category` (`user`/`system`/`conflict`/`metadata_connection_lost`), `application_name` |
+| `query_completed` | A statement finishes executing successfully | `user`, `team_id`, `trace_id`, `protocol`, `query_kind`, `duration_ms`, `cpu_seconds` (DuckDB CPU/thread-time), `result_rows`, `application_name`; Trino adds `execution_engine=trino`, `query_id`, queue/input/memory/spill/driver resource fields, `source`, and `resource_group` |
+| `query_failed` | A query errors | `user`, `team_id`, `trace_id`, `error_code` (SQLSTATE), `error_category` (`user`/`system`/`conflict`/`metadata_connection_lost`), `application_name`; Trino adds `execution_engine=trino`, `query_id`, resource fields, `error_type`, and Trino `error_code` |
 
 > Note: `warehouse_provision_success` / `_failed` and `warehouse_deprovision_success`
 > are terminal and fire exactly once per warehouse (guarded on the state
@@ -614,6 +614,13 @@ teardown), so you can build a provisioning funnel and alert on failures.
 > PostHog-side callers (e.g. the register workflow, Dagster, the SQL editor)
 > from customer `psql` connections. It is an empty string when the client
 > didn't set one.
+
+> Trino terminal queries are collected by the janitor leader every 10 seconds
+> from the coordinator and use the same `query_completed` / `query_failed`
+> events with `execution_engine=trino`. They never include SQL text. The
+> coordinator retains completed queries only temporarily, so this is
+> best-effort product telemetry rather than the billing source of truth;
+> consumers should deduplicate by `query_id` during a leader failover.
 
 ### Query Logs
 

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -789,6 +789,16 @@ func SetupMultiTenant(
 		ClusterClient: clusterClient,
 		Trino:         newTrinoAdminAPI(trinoConsole, store, auditStore),
 	})
+	if janitorLeader != nil && trinoConsole != nil {
+		// The coordinator owns the authoritative runtime view of Trino query
+		// usage. Keep its collector under the existing leader lease so one CP
+		// emits each terminal query, independent of admin-console traffic.
+		janitorLeader.AttachLeaderLoop(newTrinoUsageCollector(
+			trinoConsole.Observer,
+			store,
+			store.OrgUsageTeamID,
+		).Run)
+	}
 
 	// Trino OPA bundle endpoint. Mounted OUTSIDE the /api/v1 admin group on
 	// purpose — it does its own bearer-token auth (the bundle exposes the

--- a/controlplane/trino_usage_collector.go
+++ b/controlplane/trino_usage_collector.go
@@ -1,0 +1,142 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/admin"
+	"github.com/posthog/duckgres/internal/analytics"
+)
+
+// Trino's query endpoint retains recently finished queries only in coordinator
+// memory. Poll it from the janitor leader so every terminal query becomes one
+// product-analytics usage event without multiplying events by CP replicas.
+const (
+	trinoUsagePollInterval = 10 * time.Second
+	trinoUsageSeenTTL      = time.Hour
+)
+
+type trinoUsageTeamResolver func(orgID, username string) int64
+
+type trinoUsageCollector struct {
+	coordinator admin.TrinoCoordinatorClient
+	orgs        admin.TrinoOrgStore
+	teamID      trinoUsageTeamResolver
+	seen        map[string]time.Time
+	now         func() time.Time
+	interval    time.Duration
+}
+
+func newTrinoUsageCollector(coordinator admin.TrinoCoordinatorClient, orgs admin.TrinoOrgStore, teamID trinoUsageTeamResolver) *trinoUsageCollector {
+	return &trinoUsageCollector{
+		coordinator: coordinator,
+		orgs:        orgs,
+		teamID:      teamID,
+		seen:        make(map[string]time.Time),
+		now:         time.Now,
+		interval:    trinoUsagePollInterval,
+	}
+}
+
+// Run is a leader-only loop. A new leader may see recently completed queries
+// after failover; the query_id property lets downstream consumers deduplicate
+// that bounded overlap without ever capturing customer SQL.
+func (c *trinoUsageCollector) Run(ctx context.Context) {
+	if c == nil || c.coordinator == nil || c.orgs == nil {
+		return
+	}
+	c.collect(ctx)
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.collect(ctx)
+		}
+	}
+}
+
+func (c *trinoUsageCollector) collect(ctx context.Context) {
+	if c == nil || c.coordinator == nil || c.orgs == nil {
+		return
+	}
+	orgs, err := c.orgs.ListTrinoEnabledOrgs()
+	if err != nil {
+		slog.Warn("Trino usage collection skipped: list enabled orgs failed", "error", err)
+		return
+	}
+	orgByPrincipal := make(map[string]string, len(orgs))
+	for _, org := range orgs {
+		orgByPrincipal[org.TrinoPrincipal()] = org.OrgID
+	}
+	queries, err := c.coordinator.Queries(ctx)
+	if err != nil {
+		slog.Warn("Trino usage collection skipped: list queries failed", "error", err)
+		return
+	}
+	now := c.now()
+	for id, recordedAt := range c.seen {
+		if now.Sub(recordedAt) > trinoUsageSeenTTL {
+			delete(c.seen, id)
+		}
+	}
+	for _, query := range queries {
+		if query.State != "FINISHED" && query.State != "FAILED" {
+			continue
+		}
+		if query.QueryID == "" {
+			continue
+		}
+		if _, ok := c.seen[query.QueryID]; ok {
+			continue
+		}
+		orgID := orgByPrincipal[query.Principal]
+		if orgID == "" {
+			continue // operator queries do not represent tenant usage
+		}
+		teamID := int64(0)
+		if c.teamID != nil {
+			teamID = c.teamID(orgID, query.Principal)
+		}
+		props := trinoUsageProperties(query, teamID)
+		if query.State == "FINISHED" {
+			analytics.Default().Capture("query_completed", orgID, props)
+		} else {
+			analytics.Default().Capture("query_failed", orgID, props)
+		}
+		c.seen[query.QueryID] = now
+	}
+}
+
+func trinoUsageProperties(query admin.TrinoQuery, teamID int64) map[string]any {
+	props := map[string]any{
+		"execution_engine":       "trino",
+		"query_id":               query.QueryID,
+		"user":                   query.Principal,
+		"team_id":                teamID,
+		"duration_ms":            query.ElapsedMS,
+		"queued_ms":              query.QueuedMS,
+		"cpu_seconds":            float64(query.CPUMS) / 1000,
+		"physical_input_bytes":   query.PhysicalInputBytes,
+		"internal_network_bytes": query.InternalNetworkBytes,
+		"peak_memory_bytes":      query.PeakMemoryBytes,
+		"spilled_bytes":          query.SpilledBytes,
+		"processed_input_rows":   query.ProcessedInputRows,
+		"total_drivers":          query.TotalDrivers,
+		"queued_drivers":         query.QueuedDrivers,
+		"running_drivers":        query.RunningDrivers,
+		"completed_drivers":      query.CompletedDrivers,
+		"source":                 query.Source,
+		"resource_group":         query.ResourceGroup,
+	}
+	if query.State == "FAILED" {
+		props["error_type"] = query.ErrorType
+		props["error_code"] = query.ErrorCode
+	}
+	return props
+}

--- a/controlplane/trino_usage_collector_test.go
+++ b/controlplane/trino_usage_collector_test.go
@@ -1,0 +1,104 @@
+//go:build kubernetes
+
+package controlplane
+
+import (
+	"context"
+	"testing"
+
+	"github.com/posthog/duckgres/controlplane/admin"
+	"github.com/posthog/duckgres/controlplane/configstore"
+	"github.com/posthog/duckgres/internal/analytics"
+)
+
+type trinoUsageFakeCoordinator struct {
+	queries []admin.TrinoQuery
+	err     error
+}
+
+func (f *trinoUsageFakeCoordinator) Queries(context.Context) ([]admin.TrinoQuery, error) {
+	return f.queries, f.err
+}
+
+func (f *trinoUsageFakeCoordinator) Query(context.Context, string) (*admin.TrinoQuery, error) {
+	return nil, nil
+}
+
+func (f *trinoUsageFakeCoordinator) KillQuery(context.Context, string, string) error { return nil }
+
+func (f *trinoUsageFakeCoordinator) Nodes(context.Context) (admin.TrinoNodeInventory, error) {
+	return admin.TrinoNodeInventory{}, nil
+}
+
+func (f *trinoUsageFakeCoordinator) ServerInfo(context.Context) (*admin.TrinoServerInfo, error) {
+	return nil, nil
+}
+
+type trinoUsageFakeOrgs struct{ orgs []configstore.TrinoEnabledOrg }
+
+func (f trinoUsageFakeOrgs) ListTrinoEnabledOrgs() ([]configstore.TrinoEnabledOrg, error) {
+	return f.orgs, nil
+}
+
+func (f trinoUsageFakeOrgs) GetManagedWarehouseTrino(string) (*configstore.ManagedWarehouseTrino, error) {
+	return nil, nil
+}
+
+type trinoUsageEvent struct {
+	event string
+	org   string
+	props map[string]any
+}
+
+type trinoUsageFakeTracker struct{ events []trinoUsageEvent }
+
+func (f *trinoUsageFakeTracker) Capture(event, org string, props map[string]any) {
+	f.events = append(f.events, trinoUsageEvent{event: event, org: org, props: props})
+}
+
+func (f *trinoUsageFakeTracker) Close() {}
+
+func TestTrinoUsageCollectorCapturesTerminalQueriesOnce(t *testing.T) {
+	tracker := &trinoUsageFakeTracker{}
+	analytics.SetDefault(tracker)
+	t.Cleanup(func() { analytics.SetDefault(nil) })
+
+	coordinator := &trinoUsageFakeCoordinator{queries: []admin.TrinoQuery{
+		{QueryID: "finished", State: "FINISHED", Principal: "tenant-db", Query: "SELECT private_value", ElapsedMS: 1200, QueuedMS: 200, CPUMS: 400, PhysicalInputBytes: 12, PeakMemoryBytes: 34, ProcessedInputRows: 56, Source: "sql-editor", ResourceGroup: "global.tenant"},
+		{QueryID: "failed", State: "FAILED", Principal: "tenant-db", ElapsedMS: 800, CPUMS: 100, ErrorType: "USER_ERROR", ErrorCode: "SYNTAX_ERROR"},
+		{QueryID: "running", State: "RUNNING", Principal: "tenant-db"},
+		{QueryID: "operator", State: "FINISHED", Principal: "__observer"},
+	}}
+	collector := newTrinoUsageCollector(coordinator, trinoUsageFakeOrgs{orgs: []configstore.TrinoEnabledOrg{{OrgID: "org-a", DatabaseName: "tenant-db"}}}, func(org, user string) int64 {
+		if org != "org-a" || user != "tenant-db" {
+			t.Fatalf("team lookup = (%q, %q)", org, user)
+		}
+		return 42
+	})
+
+	collector.collect(context.Background())
+	collector.collect(context.Background())
+
+	if len(tracker.events) != 2 {
+		t.Fatalf("event count = %d, want 2", len(tracker.events))
+	}
+	completed, failed := tracker.events[0], tracker.events[1]
+	if completed.event != "query_completed" || completed.org != "org-a" {
+		t.Errorf("completed = %#v", completed)
+	}
+	if got := completed.props["execution_engine"]; got != "trino" {
+		t.Errorf("execution_engine = %v, want trino", got)
+	}
+	if got := completed.props["cpu_seconds"]; got != 0.4 {
+		t.Errorf("cpu_seconds = %v, want 0.4", got)
+	}
+	if got := completed.props["team_id"]; got != int64(42) {
+		t.Errorf("team_id = %v, want 42", got)
+	}
+	if _, ok := completed.props["query"]; ok {
+		t.Error("query text must not be captured")
+	}
+	if failed.event != "query_failed" || failed.props["error_code"] != "SYNTAX_ERROR" {
+		t.Errorf("failed = %#v", failed)
+	}
+}


### PR DESCRIPTION
## Summary
- capture terminal Trino query resource usage in existing PostHog query lifecycle events
- poll from the janitor leader with in-process query-ID deduplication and no SQL capture
- document Trino event fields and best-effort retention semantics

## Testing
- go test -count=1 -tags kubernetes ./controlplane
- just lint *(fails because unrelated untracked Iceberg integration tests reference a missing package)*