### PR TITLE
build: restore ducklake extension URLs after repo rename-back

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN : "${DUCKDB_EXTENSION_VERSION:?must be set}" \
     && mkdir -p "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}" \
     && curl -fsSL "https://github.com/PostHog/duckdb-httpfs/releases/download/${HTTPFS_EXTENSION_TAG}/httpfs-linux-${TARGETARCH}.duckdb_extension" \
       -o "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/httpfs.duckdb_extension" \
-    && curl -fsSL "https://github.com/PostHog/hoglake/releases/download/${DUCKLAKE_EXTENSION_TAG}/ducklake-linux-${TARGETARCH}.duckdb_extension" \
+    && curl -fsSL "https://github.com/PostHog/ducklake/releases/download/${DUCKLAKE_EXTENSION_TAG}/ducklake-linux-${TARGETARCH}.duckdb_extension" \
       -o "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/ducklake.duckdb_extension" \
     && curl -fsSL "${DUCKDB_EXTENSION_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/json.duckdb_extension.gz" \
       | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/json.duckdb_extension" \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -102,7 +102,7 @@ RUN : "${DUCKDB_EXTENSION_VERSION:?must be set}" \
     && mkdir -p "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}" \
     && curl -fsSL "https://github.com/PostHog/duckdb-httpfs/releases/download/${HTTPFS_EXTENSION_TAG}/httpfs-linux-${TARGETARCH}.duckdb_extension" \
       -o "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/httpfs.duckdb_extension" \
-    && curl -fsSL "https://github.com/PostHog/hoglake/releases/download/${DUCKLAKE_EXTENSION_TAG}/ducklake-linux-${TARGETARCH}.duckdb_extension" \
+    && curl -fsSL "https://github.com/PostHog/ducklake/releases/download/${DUCKLAKE_EXTENSION_TAG}/ducklake-linux-${TARGETARCH}.duckdb_extension" \
       -o "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/ducklake.duckdb_extension" \
     && curl -fsSL "${DUCKDB_EXTENSION_REPOSITORY}/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/json.duckdb_extension.gz" \
       | gunzip > "/build/duckdb-extensions/v${DUCKDB_EXTENSION_VERSION}/linux_${TARGETARCH}/json.duckdb_extension" \


### PR DESCRIPTION
## Problem

The fork repo is being renamed `hoglake` → `ducklake` (its original name), and a **new, unrelated** repo will take the `hoglake` name. Creating that repo severs GitHub's rename redirect — at that moment the #1137 URLs (`PostHog/hoglake/releases/...`) stop redirecting to the fork and resolve against the new repo, 404ing every image build.

## Changes

Reverts #1137's surviving references: the two extension-download URLs in `Dockerfile` / `Dockerfile.worker` back to `PostHog/ducklake`. (#1137 also touched three workflow files; later commits already removed those references.)

Safe in every interim state, verified today:
- the `ducklake` → `hoglake` redirect from the original rename is still live — both `linux-amd64` and `linux-arm64` `v1.0-posthog.7` assets fetch 200 through it
- after the rename-back the URL is a direct hit

## How did you test this code?

Curl-verified both arch assets resolve via the restored URLs. No other `hoglake` references remain in the tree (case-insensitive sweep).