### PR TITLE
chore: update Trino benchmark image

### DIFF
--- a/.github/workflows/scenario-dev.yml
+++ b/.github/workflows/scenario-dev.yml
@@ -79,7 +79,7 @@ jobs:
       # Frozen perf uses a namespace-local Trino cell. The dedicated role is
       # consumed only when E2E_SUITE selects that isolated deployment.
       TRINO_POD_IDENTITY_ROLE: ${{ secrets.MW_DEV_TRINO_POD_IDENTITY_ROLE }}
-      TRINO_IMAGE: ghcr.io/posthog/trino:b239980432446a9893a811282217039bab24f1c4@sha256:4e459a87deb4f567858c6d537e143ef4e9411c17325269231a5a2074e0c135d8
+      TRINO_IMAGE: ghcr.io/posthog/trino:59184e0c58c2fdbde031f3a08787c926dc4d7f69@sha256:a7072f7c86fcbb815c2502bb455b27bc4679d201ad6ce81725378a7c5ce84325
       E2E_SUITE: ${{ (matrix.scenario == 'posthog_frozen_perf' || matrix.scenario == 'posthog_frozen_perf_trino_cached') && 'trino' || 'neutral' }}
       PR_NUMBER: ${{ github.run_id }}${{ strategy.job-index }}
       NAMESPACE: duckgres-ci-pr-${{ github.run_id }}${{ strategy.job-index }}


### PR DESCRIPTION
The scheduled benchmark still pins a Trino image from before PostHog/trino#31, so runs on Duckgres main do not exercise the redundant Parquet index-read optimization.

Update the shared `TRINO_IMAGE` pin to the PR #31 merge commit, `59184e0c58c2fdbde031f3a08787c926dc4d7f69`, with its verified immutable GHCR digest. Both standard and cached Trino scenarios use this image.

Validation:
- Verified the GHCR tag resolves to the pinned digest and includes a Linux ARM64 manifest.
- `just test-scenario` passed.
- `git diff --check` passed; focused review found no issues.
- `just lint` reports six Staticcheck SA4023 diagnostics in unchanged Go files (`main.go`, `cmd/duckgres-controlplane/main.go`, and `controlplane/control.go`).

This updates the benchmark input; it does not establish a performance gain. The benchmark has not been rerun with this pin yet.
