### PR TITLE
feat: support explicit registry-only Trino deployments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -921,7 +921,7 @@ impersonation, audit log; sliceable by org + user). Design + decisions:
   Every read is cached + timeout-bounded and degrades to `available:false`
   plus a reason rather than erroring the page: the console must render
   during exactly the incident it exists for. Unset
-  `DUCKGRES_TRINO_COORDINATOR_URL` leaves the routes unregistered.
+  legacy URL and registry configuration leaves the routes unregistered.
 - Touching any of the above → update `controlplane/admin/*_test.go` (esp
   `authz_test.go`, `kill_switch_test.go`, `operators_api_test.go`,
   `trino_test.go`, `trino_client_test.go`),
@@ -1553,7 +1553,10 @@ projects it every controller tick from `duckgres_managed_warehouse_trino` +
 the org's warehouse row + its Duckling CR. Enablement is env-inferred —
 `DUCKGRES_TRINO_COORDINATOR_URL` identifies legacy (`controlplane/trino_inputs.go`).
 The optional `DUCKGRES_TRINO_CELLS_FILE` adds namespace-isolated logical cells
-with blue/green backends; it still requires legacy configuration. With neither
+with blue/green backends. It requires legacy unless
+`DUCKGRES_TRINO_REGISTRY_ONLY=true` explicitly selects a registry-only deployment.
+That mode requires a valid registry and forbids a legacy coordinator URL.
+It never claims unassigned warehouses or reinterprets legacy ownership. With neither
 setting, the branch never wires and nothing changes. **Trino is binary: if
 you asked for it, a wiring failure is fatal at startup**, because silently
 skipping leaves the cell's OPA sidecar serving a last-good bundle while

--- a/controlplane/admin/README.md
+++ b/controlplane/admin/README.md
@@ -198,7 +198,10 @@ returns the persisted `trino.trino_cell_id`. Registered cells use separate
 `registered:<cell-id>` ownership values. Unknown stored owners fail closed.
 
 `GET /api/v1/trino/cells` lists configured logical cells. Operational Trino
-routes accept `?cell=<logical-id>` and default to `legacy`. Org detail resolves
+routes accept `?cell=<logical-id>` and default to `legacy` only when configured.
+Registry-only deployments require an explicit cell parameter; the Trino pages
+provide a cell selector. Unassigned org details expose no coordinator or client
+coordinates and allow initial selection before enablement. Org detail resolves
 its authoritative stored assignment regardless of a supplied cell parameter.
 Each coordinator has separate caches; tenant counts include only its cell.
 
@@ -280,7 +283,7 @@ an API consumer requires the previous displayed ID.
 - Neither route carries a node id or version, so worker version skew is not
   observable there; the Nodes page's pod projection (running images) is where
   that lives.
-- No cell configured (`DUCKGRES_TRINO_COORDINATOR_URL` unset) leaves every
+- No legacy URL or registry configured leaves every
   route unregistered, and the SPA renders a "no cell" state off the 404.
 
 Touching this → update `trino_test.go`, `trino_client_test.go`,

--- a/controlplane/admin/trino_fleet.go
+++ b/controlplane/admin/trino_fleet.go
@@ -47,6 +47,10 @@ func registerTrinoFleetAPI(r *gin.RouterGroup, api *TrinoAPI) {
 
 func (a *TrinoAPI) forCell(handle func(*TrinoAPI, *gin.Context)) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if _, explicit := c.GetQuery("cell"); !explicit && a.fleet["legacy"] == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "explicit Trino cell selection is required"})
+			return
+		}
 		id := c.DefaultQuery("cell", "legacy")
 		selected := a.fleet[id]
 		if selected == nil {
@@ -73,6 +77,14 @@ func (a *TrinoAPI) handleFleetOrg(c *gin.Context) {
 		return
 	}
 	selected := a.fleet["legacy"]
+	if selected == nil && (row == nil || row.TrinoCellID == "") {
+		response := gin.H{"cell": TrinoCell{}, "enabled": row != nil && row.Enabled, "assigned": false, "available": false}
+		if row != nil && row.Enabled {
+			response["status"] = TrinoOrgStatus{Org: c.Param("id"), Tier: row.Tier, State: string(configstore.ManagedWarehouseStatePending), StatusMessage: "No Trino cell is assigned. Disable Trino, select an initial cell, then enable it again."}
+		}
+		c.JSON(http.StatusOK, response)
+		return
+	}
 	if row != nil && row.TrinoCellID != "" {
 		selected = nil
 		for _, candidate := range a.fleet {

--- a/controlplane/admin/trino_fleet_test.go
+++ b/controlplane/admin/trino_fleet_test.go
@@ -9,6 +9,51 @@ import (
 	"github.com/posthog/duckgres/controlplane/configstore"
 )
 
+func TestTrinoRegistryOnlyAdminHasNoImplicitCell(t *testing.T) {
+	client := &fakeTrinoCoordinator{}
+	store := &selectingTrinoStore{fakeTrinoOrgStore: fakeTrinoOrgStore{rows: map[string]*configstore.ManagedWarehouseTrino{}}}
+	api := NewTrinoFleetAPI([]TrinoCell{{ID: "cell-test", StoredID: "registered:cell-test", ClientURL: "https://gateway.example.test"}}, []TrinoCoordinatorClient{client}, store, nil)
+	r := trinoTestRouter(api, RoleAdmin)
+	for _, path := range []string{"status", "queries", "nodes", "orgs", "queries/query"} {
+		code, _ := doTrinoJSON(t, r, http.MethodGet, "/api/v1/trino/"+path, "")
+		if code != http.StatusBadRequest {
+			t.Errorf("missing explicit cell for %s: %d", path, code)
+		}
+	}
+	for _, row := range []*configstore.ManagedWarehouseTrino{nil, {OrgID: "tenant"}, {OrgID: "tenant", Enabled: true, State: configstore.ManagedWarehouseStateReady}} {
+		store.rows["tenant"] = row
+		code, data := doTrinoJSON(t, r, http.MethodGet, "/api/v1/orgs/tenant/trino", "")
+		if code != http.StatusOK || data["assigned"] != false || data["available"] != false || data["cell"].(map[string]any)["id"] != "" {
+			t.Fatalf("unassigned detail: %d %#v", code, data)
+		}
+		if row != nil && row.Enabled {
+			status := data["status"].(map[string]any)
+			if status["connection"] != nil || status["state"] != "pending" || status["status_message"] == "" {
+				t.Fatalf("unassigned falsely ready: %#v", status)
+			}
+		}
+	}
+	for _, owner := range []string{"cell-001", "legacy", "unknown"} {
+		store.rows["tenant"] = &configstore.ManagedWarehouseTrino{OrgID: "tenant", Enabled: true, TrinoCellID: owner}
+		code, _ := doTrinoJSON(t, r, http.MethodGet, "/api/v1/orgs/tenant/trino", "")
+		if code != http.StatusConflict || store.rows["tenant"].TrinoCellID != owner {
+			t.Fatalf("unknown owner changed or accepted: %s %d", owner, code)
+		}
+	}
+	if client.queryCalls.Load() != 0 {
+		t.Fatal("unassigned/unknown rows reached a coordinator")
+	}
+	store.rows["tenant"] = &configstore.ManagedWarehouseTrino{OrgID: "tenant"}
+	code, _ := doTrinoJSON(t, r, http.MethodPut, "/api/v1/orgs/tenant/trino/cell", `{"cell":"cell-test"}`)
+	if code != http.StatusOK || store.selected != "registered:cell-test" {
+		t.Fatalf("explicit selection failed: %d", code)
+	}
+	code, _ = doTrinoJSON(t, r, http.MethodGet, "/api/v1/trino/queries?cell=cell-test", "")
+	if code != http.StatusOK {
+		t.Fatalf("explicit cell unavailable: %d", code)
+	}
+}
+
 func TestTrinoFleetSelectsAuthoritativeOwner(t *testing.T) {
 	legacy := &fakeTrinoCoordinator{}
 	current := &fakeTrinoCoordinator{queries: []TrinoQuery{{Principal: "tenant"}}}

--- a/controlplane/admin/ui/src/components/TrinoCellPicker.test.tsx
+++ b/controlplane/admin/ui/src/components/TrinoCellPicker.test.tsx
@@ -1,0 +1,29 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+
+const hooks = vi.hoisted(() => ({ useTrinoCells: vi.fn() }));
+vi.mock("@/hooks/useApi", () => hooks);
+import { TrinoCellPicker } from "./TrinoCellPicker";
+
+function Location() { return <output aria-label="Location">{useLocation().search}</output>; }
+function mount(path = "/trino/queries?active=true") {
+  render(<MemoryRouter initialEntries={[path]}><TrinoCellPicker /><Location /></MemoryRouter>);
+}
+beforeEach(() => hooks.useTrinoCells.mockReturnValue({ data: { cells: [{ id: "cell-test" }] } }));
+it("requires explicit selection even when only one registered cell exists", () => {
+  mount();
+  expect(screen.getByLabelText("Trino cell")).toHaveValue("");
+  expect(screen.getByLabelText("Location")).toHaveTextContent("?active=true");
+  fireEvent.change(screen.getByLabelText("Trino cell"), { target: { value: "cell-test" } });
+  expect(screen.getByLabelText("Location")).toHaveTextContent("active=true&cell=cell-test");
+});
+it("preserves the legacy operational default only when configured", () => {
+  hooks.useTrinoCells.mockReturnValue({ data: { cells: [{ id: "legacy" }, { id: "cell-test" }] } });
+  mount();
+  expect(screen.getByLabelText("Trino cell")).toHaveValue("legacy");
+});
+it("does not silently replace an unknown explicit cell", () => {
+  mount("/trino/queries?cell=removed");
+  expect(screen.getByLabelText("Location")).toHaveTextContent("cell=removed");
+});

--- a/controlplane/admin/ui/src/components/TrinoCellPicker.tsx
+++ b/controlplane/admin/ui/src/components/TrinoCellPicker.tsx
@@ -1,0 +1,26 @@
+import { useSearchParams } from "react-router-dom";
+import { useTrinoCells } from "@/hooks/useApi";
+
+export function TrinoCellPicker() {
+  const cells = useTrinoCells();
+  const [params, setParams] = useSearchParams();
+  const entries = cells.data?.cells ?? [];
+  const selected = params.get("cell") ?? (entries.some((cell) => cell.id === "legacy") ? "legacy" : "");
+  if (!entries.length) return null;
+  return (
+    <select
+      aria-label="Trino cell"
+      className="h-8 rounded border bg-background px-2 text-sm"
+      value={selected}
+      onChange={(event) => setParams((previous) => {
+        const next = new URLSearchParams(previous);
+        next.set("cell", event.target.value);
+        return next;
+      })}
+    >
+      <option value="" disabled>Choose a cell</option>
+      {selected && !entries.some((cell) => cell.id === selected) && <option value={selected} disabled>Unknown cell: {selected}</option>}
+      {entries.map((cell) => <option key={cell.id} value={cell.id}>{cell.id}</option>)}
+    </select>
+  );
+}

--- a/controlplane/admin/ui/src/pages/TrinoCluster.tsx
+++ b/controlplane/admin/ui/src/pages/TrinoCluster.tsx
@@ -8,6 +8,7 @@ import { StatCard } from "@/components/StatCard";
 import { StateBadge } from "@/components/StateBadge";
 import { EmptyState, TableSkeleton } from "@/components/states";
 import { OrgRef } from "@/components/OrgRef";
+import { TrinoCellPicker } from "@/components/TrinoCellPicker";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useOrgLabels, useTrinoNodes, useTrinoOrgs, useTrinoStatus } from "@/hooks/useApi";
 import { fmtDurationMs, fmtInt, fmtPercent, fmtTime } from "@/lib/format";
@@ -45,6 +46,7 @@ export function TrinoCluster() {
     <>
       <PageHeader
         title="Trino cell"
+        actions={<TrinoCellPicker />}
         description={
           status.data?.cell.id
             ? `${status.data.cell.id} · ${status.data.cell.coordinator_url}`

--- a/controlplane/admin/ui/src/pages/TrinoQueries.test.tsx
+++ b/controlplane/admin/ui/src/pages/TrinoQueries.test.tsx
@@ -9,6 +9,7 @@ const hooks = vi.hoisted(() => ({
   useOrgLabels: vi.fn(),
   useTrinoQueries: vi.fn(),
   useTrinoStatus: vi.fn(),
+  useTrinoCells: vi.fn(),
 }));
 vi.mock("@/hooks/useApi", () => hooks);
 
@@ -85,6 +86,7 @@ function statValue(label: string): string {
 describe("TrinoQueries page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    hooks.useTrinoCells.mockReturnValue(ok({ cells: [{ id: "legacy" }] }));
     identity.useIdentity.mockReturnValue({ isAdmin: true });
     hooks.useKillTrinoQuery.mockReturnValue({ mutate: vi.fn(), isPending: false, isError: false });
     hooks.useOrgLabels.mockReturnValue(new Map([["org-a-id", "product_analytics"]]));

--- a/controlplane/admin/ui/src/pages/TrinoQueries.tsx
+++ b/controlplane/admin/ui/src/pages/TrinoQueries.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { StatCard } from "@/components/StatCard";
 import { EmptyState, ErrorState, TableSkeleton } from "@/components/states";
 import { OrgRef } from "@/components/OrgRef";
+import { TrinoCellPicker } from "@/components/TrinoCellPicker";
 import { AdminGate } from "@/components/AdminOnly";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import {
@@ -149,6 +150,7 @@ export function TrinoQueries() {
         }
         actions={
           <div className="flex items-center gap-2">
+            <TrinoCellPicker />
             <Input
               className="h-8 w-56"
               placeholder="Filter by org or principal…"

--- a/controlplane/multitenant.go
+++ b/controlplane/multitenant.go
@@ -511,14 +511,13 @@ func SetupMultiTenant(
 	provCtrl, err := provisioner.NewController(store, 10*time.Second)
 	if err != nil {
 		// Without the controller, the Trino reconcile loop cannot run.
-		// If the operator asked for Trino explicitly (URL set), that's a
+		// If the operator configured Trino, that's a
 		// fatal startup failure — same "Trino is binary" stance as the
 		// wiring-failure branch below. Without this check, the Trino
 		// branch would be silently skipped (it's nested in the else)
 		// and password/group/tenant/bundle projections would stop updating.
 		if trinoProvisionerEnabled() {
-			return nil, nil, nil, nil, nil, nil, fmt.Errorf("trino provisioner enabled (%s set) but provisioning controller unavailable: %w",
-				envTrinoCoordinatorURL, err)
+			return nil, nil, nil, nil, nil, nil, fmt.Errorf("trino provisioner configured but provisioning controller unavailable: %w", err)
 		}
 		slog.Warn("Provisioning controller unavailable.", "error", err)
 	} else {
@@ -527,8 +526,8 @@ func SetupMultiTenant(
 		// it disabled (composition keeps deriving).
 		provCtrl.WithBucketSuffix(cfg.DucklingBucketSuffix)
 		// Trino cell provisioner branch. Enablement is signaled by setting
-		// DUCKGRES_TRINO_COORDINATOR_URL (no separate boolean gate — the
-		// URL is the intent). When enabled, wiring failure is fatal:
+		// a legacy coordinator URL or explicit registry configuration.
+		// When enabled, wiring failure is fatal:
 		// silently skipping would leave the cell's OPA sidecar serving the
 		// last-good bundle while password/group-file and tenant-password
 		// changes never propagate, which is worse than failing the rollout.
@@ -536,8 +535,7 @@ func SetupMultiTenant(
 		if trinoProvisionerEnabled() {
 			kc, tkErr := newTrinoKubeClient()
 			if tkErr != nil {
-				return nil, nil, nil, nil, nil, nil, fmt.Errorf("trino provisioner enabled (%s set) but K8s client unavailable: %w",
-					envTrinoCoordinatorURL, tkErr)
+				return nil, nil, nil, nil, nil, nil, fmt.Errorf("trino provisioner configured but K8s client unavailable: %w", tkErr)
 			}
 			// Same Duckling CR read the worker activation path uses; nil
 			// when the Duckling client couldn't be built, which
@@ -752,7 +750,7 @@ func SetupMultiTenant(
 	if len(cfg.ManagedHostnameSuffixes) > 0 {
 		ingressSuffix = cfg.ManagedHostnameSuffixes[0]
 	}
-	provisioning.RegisterAPIWithIngressSuffix(api, gormStore, gormStore, cfg.DucklingBucketSuffix, liveFetcher, ingressSuffix)
+	provisioning.RegisterAPIWithTrinoAdmission(api, gormStore, gormStore, cfg.DucklingBucketSuffix, liveFetcher, ingressSuffix, trinoCells.enablementCheck(store))
 	// Discovery endpoints live in their OWN group (see discovery_group.go
 	// for the security rationale and the topology tripwire test).
 	registerReadOnlyGroup(engine, readOnlyTokens, adminTokens, provisioning.NewGormStore(store))

--- a/controlplane/provisioner/trino_cell_backends_test.go
+++ b/controlplane/provisioner/trino_cell_backends_test.go
@@ -113,6 +113,35 @@ func TestTrinoRegisteredCellNeverClaimsUnassignedTenants(t *testing.T) {
 	}
 }
 
+func TestTrinoRegistryOnlyCannotProjectLegacyOrUnassignedTenants(t *testing.T) {
+	orgs := []configstore.TrinoEnabledOrg{
+		{OrgID: "old", DatabaseName: "old", CellID: "cell-001", RootPasswordHash: "old-hash"},
+		{OrgID: "unassigned", DatabaseName: "unassigned", RootPasswordHash: "unassigned-hash"},
+		{OrgID: "selected", DatabaseName: "selected", CellID: "registered:cell-test", RootPasswordHash: "selected-hash"},
+	}
+	h := newTestTrinoProvisioner(t, orgs, map[string]*configstore.ManagedWarehouse{"old": readyWarehouse("old"), "unassigned": readyWarehouse("unassigned"), "selected": readyWarehouse("selected")})
+	h.provisioner.cellID = "registered:cell-test"
+	h.provisioner.explicitAssignmentOnly = true
+	if err := h.provisioner.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.store.claimLog) != 0 || len(h.catalog.created) != 1 || h.catalog.created[TrinoCatalogName("selected")] == nil {
+		t.Fatal("registry-only projected or claimed an unowned tenant")
+	}
+	auth := getSecret(t, h.kube, TrinoAuthSecretName)
+	for _, org := range []string{"old", "unassigned"} {
+		if _, ok := h.store.lastState(org); ok {
+			t.Fatal("unowned state mutated")
+		}
+		if strings.Contains(string(auth.Data[TrinoAuthSecretKeyPasswordDB]), org+":") || h.builder.last[TrinoGroupName(org)] != nil {
+			t.Fatal("unowned auth/OPA leaked")
+		}
+	}
+	if state, ok := h.store.lastState("selected"); !ok || state.State != configstore.ManagedWarehouseStateReady {
+		t.Fatal("selected tenant did not provision")
+	}
+}
+
 type lostClaimStore struct{ *fakeTrinoStore }
 
 func (s lostClaimStore) AssignTrinoCell(string, string) error        { return nil }

--- a/controlplane/provisioning/api.go
+++ b/controlplane/provisioning/api.go
@@ -137,7 +137,12 @@ func RegisterAPI(r *gin.RouterGroup, store Store, tenantStore TenantStore, bucke
 // response hands back is the ingress the credential authenticates against. An
 // empty ingressSuffix falls back to DefaultManagedIngressSuffix.
 func RegisterAPIWithIngressSuffix(r *gin.RouterGroup, store Store, tenantStore TenantStore, bucketSuffix string, peerFanout PeerFanout, ingressSuffix string) {
-	h := &handler{store: store, bucketSuffix: bucketSuffix, peerFanout: peerFanout, ingressSuffix: ingressSuffix}
+	RegisterAPIWithTrinoAdmission(r, store, tenantStore, bucketSuffix, peerFanout, ingressSuffix, nil)
+}
+
+// RegisterAPIWithTrinoAdmission optionally checks cell assignment before enabling Trino.
+func RegisterAPIWithTrinoAdmission(r *gin.RouterGroup, store Store, tenantStore TenantStore, bucketSuffix string, peerFanout PeerFanout, ingressSuffix string, admission func(string) error) {
+	h := &handler{store: store, bucketSuffix: bucketSuffix, peerFanout: peerFanout, ingressSuffix: ingressSuffix, trinoAdmission: admission}
 	r.POST("/orgs/:id/provision", h.provisionWarehouse)
 	r.POST("/orgs/:id/deprovision", h.deprovisionWarehouse)
 	r.GET("/orgs/:id/warehouse/status", h.getWarehouseStatus)
@@ -180,7 +185,8 @@ func RegisterDiscoveryAPI(r *gin.RouterGroup, store Store) {
 }
 
 type handler struct {
-	store Store
+	store          Store
+	trinoAdmission func(string) error
 	// bucketSuffix is the env suffix (e.g. "mw-prod-us") used to compute the
 	// CP-owned s3bucket name; empty disables CP naming. See
 	// configstore.DucklingBucketName.
@@ -483,6 +489,9 @@ func (h *handler) provisionWarehouse(c *gin.Context) {
 	// extra per-Trino constraint.
 	var trinoSettings *configstore.TrinoSettings
 	if req.Trino != nil && req.Trino.Enabled {
+		if !h.admitTrino(c, orgID) {
+			return
+		}
 		trinoSettings = &configstore.TrinoSettings{Tier: req.Trino.Tier}
 	}
 
@@ -623,6 +632,9 @@ func (h *handler) enableTrino(c *gin.Context) {
 		return
 	}
 
+	if !h.admitTrino(c, orgID) {
+		return
+	}
 	if err := h.store.EnableTrino(orgID, configstore.TrinoSettings{Tier: req.Tier}); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/controlplane/provisioning/trino_admission.go
+++ b/controlplane/provisioning/trino_admission.go
@@ -1,0 +1,26 @@
+package provisioning
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+var ErrTrinoCellSelectionRequired = errors.New("select an initial Trino cell before enabling Trino")
+var ErrTrinoCellNotConfigured = errors.New("the assigned Trino cell is not configured")
+
+func (h *handler) admitTrino(c *gin.Context, orgID string) bool {
+	if h.trinoAdmission == nil {
+		return true
+	}
+	if err := h.trinoAdmission(orgID); err != nil {
+		if errors.Is(err, ErrTrinoCellSelectionRequired) || errors.Is(err, ErrTrinoCellNotConfigured) {
+			c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "cannot verify Trino cell assignment"})
+		}
+		return false
+	}
+	return true
+}

--- a/controlplane/provisioning/trino_admission_test.go
+++ b/controlplane/provisioning/trino_admission_test.go
@@ -1,0 +1,64 @@
+package provisioning
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+func TestTrinoAdmissionGuardsBothEnableSurfaces(t *testing.T) {
+	for _, endpoint := range []string{"trino", "provision"} {
+		for _, allowed := range []bool{false, true} {
+			store := newFakeStore()
+			store.orgs["tenant"] = &configstore.Org{Name: "tenant"}
+			store.users[configstore.OrgUserKey{OrgID: "tenant", Username: "root"}] = "hash"
+			r := gin.New()
+			calls := 0
+			RegisterAPIWithTrinoAdmission(r.Group("/api/v1"), store, store, "", nil, "", func(org string) error {
+				calls++
+				if org != "tenant" {
+					t.Fatalf("wrong org %s", org)
+				}
+				if !allowed {
+					return ErrTrinoCellSelectionRequired
+				}
+				return nil
+			})
+			body := `{"enabled":true,"tier":"free"}`
+			if endpoint == "provision" {
+				body = `{"database_name":"tenant","team_id":1,"metadata_store":{"type":"cnpg-shard"},"ducklake":{"enabled":true},"trino":{"enabled":true}}`
+			}
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/tenant/"+endpoint, bytes.NewBufferString(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+			want := http.StatusConflict
+			if allowed {
+				want = http.StatusAccepted
+			}
+			if rec.Code != want || calls != 1 {
+				t.Fatalf("%s allowed=%v status=%d calls=%d body=%s", endpoint, allowed, rec.Code, calls, rec.Body.String())
+			}
+			if !allowed && (store.trino["tenant"] != nil || store.lastProvision != nil) {
+				t.Fatal("admission rejection mutated warehouse")
+			}
+		}
+	}
+}
+
+func TestTrinoAdmissionHidesStoreErrors(t *testing.T) {
+	h := &handler{trinoAdmission: func(string) error { return errors.New("private database endpoint") }}
+	r := gin.New()
+	r.GET("/", func(c *gin.Context) { h.admitTrino(c, "tenant") })
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusInternalServerError || strings.Contains(rec.Body.String(), "private database") {
+		t.Fatalf("unsafe error: %d %s", rec.Code, rec.Body.String())
+	}
+}

--- a/controlplane/trino_fleet.go
+++ b/controlplane/trino_fleet.go
@@ -12,12 +12,13 @@ import (
 	"github.com/posthog/duckgres/controlplane/admin"
 	"github.com/posthog/duckgres/controlplane/configstore"
 	"github.com/posthog/duckgres/controlplane/provisioner"
+	"github.com/posthog/duckgres/controlplane/provisioning"
 	"k8s.io/client-go/kubernetes"
 )
 
 type trinoFleet []*trinoWiring
 
-func buildTrinoFleetWiring(store *configstore.ConfigStore, kc kubernetes.Interface, ducklings provisioner.TrinoDucklingResolver) (trinoFleet, error) {
+func buildTrinoFleetWiring(store trinoWiringStore, kc kubernetes.Interface, ducklings provisioner.TrinoDucklingResolver) (trinoFleet, error) {
 	if !trinoProvisionerEnabled() {
 		return nil, nil
 	}
@@ -34,6 +35,35 @@ func buildTrinoFleetWiring(store *configstore.ConfigStore, kc kubernetes.Interfa
 		fleet = append(fleet, wire)
 	}
 	return fleet, nil
+}
+
+// enablementCheck requires explicit placement when no legacy provisioner exists.
+func (f trinoFleet) enablementCheck(store interface {
+	GetManagedWarehouseTrino(string) (*configstore.ManagedWarehouseTrino, error)
+}) func(string) error {
+	if len(f) == 0 {
+		return nil
+	}
+	owners := make(map[string]bool, len(f))
+	for _, wire := range f {
+		if wire.Cell.PublicID == "" {
+			return nil
+		}
+		owners[wire.Cell.ID] = true
+	}
+	return func(orgID string) error {
+		row, err := store.GetManagedWarehouseTrino(orgID)
+		if err != nil {
+			return err
+		}
+		if row == nil || row.TrinoCellID == "" {
+			return provisioning.ErrTrinoCellSelectionRequired
+		}
+		if !owners[row.TrinoCellID] {
+			return provisioning.ErrTrinoCellNotConfigured
+		}
+		return nil
+	}
 }
 
 // Reconcile isolates cell failures and bounds each cell's external API work.

--- a/controlplane/trino_fleet_test.go
+++ b/controlplane/trino_fleet_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -14,10 +16,96 @@ import (
 	"github.com/posthog/duckgres/controlplane/configstore"
 	"github.com/posthog/duckgres/controlplane/provisioner"
 	"github.com/posthog/duckgres/controlplane/provisioner/opa"
+	"github.com/posthog/duckgres/controlplane/provisioning"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 )
+
+type registryOnlyOrgStore struct {
+	row *configstore.ManagedWarehouseTrino
+	err error
+}
+
+func (s registryOnlyOrgStore) GetManagedWarehouseTrino(string) (*configstore.ManagedWarehouseTrino, error) {
+	return s.row, s.err
+}
+
+func TestTrinoRegistryOnlyAdmissionUsesStoredOwnership(t *testing.T) {
+	fleet := trinoFleet{&trinoWiring{Cell: trinoCell{ID: "registered:cell-test", PublicID: "cell-test"}}}
+	for _, tc := range []struct {
+		owner string
+		want  error
+	}{
+		{"", provisioning.ErrTrinoCellSelectionRequired}, {"cell-001", provisioning.ErrTrinoCellNotConfigured},
+		{"legacy", provisioning.ErrTrinoCellNotConfigured}, {"registered:unknown", provisioning.ErrTrinoCellNotConfigured}, {"registered:cell-test", nil},
+	} {
+		store := registryOnlyOrgStore{row: &configstore.ManagedWarehouseTrino{TrinoCellID: tc.owner}}
+		if err := fleet.enablementCheck(store)("tenant"); !errors.Is(err, tc.want) {
+			t.Fatalf("owner %q: %v", tc.owner, err)
+		}
+	}
+	if err := fleet.enablementCheck(registryOnlyOrgStore{})("tenant"); !errors.Is(err, provisioning.ErrTrinoCellSelectionRequired) {
+		t.Fatal("missing row admitted")
+	}
+	dbErr := errors.New("database unavailable")
+	if err := fleet.enablementCheck(registryOnlyOrgStore{err: dbErr})("tenant"); !errors.Is(err, dbErr) {
+		t.Fatal("read failure admitted")
+	}
+	fleet = append(fleet, &trinoWiring{Cell: trinoCell{ID: "cell-001"}})
+	if fleet.enablementCheck(registryOnlyOrgStore{}) != nil || (trinoFleet(nil)).enablementCheck(registryOnlyOrgStore{}) != nil {
+		t.Fatal("legacy or disabled behavior changed")
+	}
+}
+
+func TestTrinoRegistryOnlyBootstrapHasNoLegacyDependency(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cells.json")
+	if err := os.WriteFile(path, []byte(testTrinoRegistryJSON), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envTrinoCellsFile, path)
+	t.Setenv(envTrinoCoordinatorURL, "")
+	t.Setenv(envTrinoRegistryOnly, "true")
+	t.Setenv(envTrinoNamespace, "unused-legacy")
+	t.Setenv(envTrinoFilesystemCacheEnabled, "false")
+	store := &fleetBootstrapStore{initialized: map[string]bool{}}
+	kc := kubefake.NewClientset()
+	for _, name := range []string{"blue-internal", "green-internal"} {
+		_, err := kc.CoreV1().Secrets("trino-test").Create(context.Background(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name}, Data: map[string][]byte{"shared-secret": []byte("fixture-" + name)}}, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	fleet, err := buildTrinoFleetWiring(store, kc, func(context.Context, string) (*provisioner.DucklingStatus, error) { return nil, nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fleet) != 1 || len(store.initialized) != 1 || !store.initialized["trino-test"] {
+		t.Fatal("legacy was bootstrapped")
+	}
+	for _, action := range kc.Actions() {
+		if action.GetNamespace() != "trino-test" {
+			t.Fatalf("unexpected namespace request %s", action.GetNamespace())
+		}
+	}
+	engine := gin.New()
+	wire := fleet[0]
+	wire.BundleStore.Set(opa.NewBundle([]byte("registered")))
+	engine.Any(wire.bundlePath(), gin.WrapH(wire.BundleHandler))
+	secret, err := kc.CoreV1().Secrets("trino-test").Get(context.Background(), provisioner.TrinoOPABundleTokenSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for path, want := range map[string]int{"/bundles/trino": http.StatusNotFound, "/bundles/trino/cell-test": http.StatusOK} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("Authorization", "Bearer "+string(secret.Data["token"]))
+		rec := httptest.NewRecorder()
+		engine.ServeHTTP(rec, req)
+		if rec.Code != want {
+			t.Fatalf("bundle %s: %d", path, rec.Code)
+		}
+	}
+}
 
 type fleetCatalog struct {
 	called chan struct{}

--- a/controlplane/trino_inputs.go
+++ b/controlplane/trino_inputs.go
@@ -38,12 +38,10 @@ func newTrinoKubeClient() (kubernetes.Interface, error) {
 //
 // Intent inference (no explicit on/off gate):
 //
-//	Enablement is signaled by setting DUCKGRES_TRINO_COORDINATOR_URL.
-//	If the URL is empty, the provisioner branch is off and existing
-//	non-MW deployments stay unaffected. If the URL is set, the other
-//	required env vars must also be set; missing-required-value errors
-//	are fatal at startup (silently no-op'ing wouldn't help — the chart
-//	side would be waiting forever for projections that never come).
+//	A coordinator URL or registry configuration enables the branch.
+//	Registry-only deployments require explicit opt-in and a valid registry.
+//	Invalid or incomplete requested configuration fails startup.
+//	With neither configuration, existing deployments remain unaffected.
 //
 // Credentials are NOT env vars:
 //
@@ -56,8 +54,8 @@ func newTrinoKubeClient() (kubernetes.Interface, error) {
 const (
 	// envTrinoCoordinatorURL is the Trino coordinator's REST endpoint,
 	// e.g. https://trino-coordinator.trino-customer.svc:8443. Setting
-	// this to a non-empty value enables the Trino provisioner branch;
-	// leaving it empty disables it. Required configuration when enabled.
+	// this to a non-empty value enables the legacy Trino provisioner.
+	// Only explicit registry-only mode permits a fleet without this URL.
 	//
 	// This URL continues to identify the legacy cell when a registry is mounted.
 	envTrinoCoordinatorURL = "DUCKGRES_TRINO_COORDINATOR_URL"
@@ -114,9 +112,11 @@ const (
 )
 
 // trinoProvisionerEnabled recognizes legacy or registry configuration.
-// A registry still requires the legacy URL to preserve existing ownership.
+// Registry-only mode must reach validation even when its registry is missing.
 func trinoProvisionerEnabled() bool {
-	return strings.TrimSpace(os.Getenv(envTrinoCoordinatorURL)) != "" || strings.TrimSpace(os.Getenv(envTrinoCellsFile)) != ""
+	mode := strings.TrimSpace(os.Getenv(envTrinoRegistryOnly))
+	registryOnly, err := strconv.ParseBool(mode)
+	return strings.TrimSpace(os.Getenv(envTrinoCoordinatorURL)) != "" || strings.TrimSpace(os.Getenv(envTrinoCellsFile)) != "" || registryOnly || (mode != "" && err != nil)
 }
 
 // trinoCell separates durable ownership from the operator-visible identity.

--- a/controlplane/trino_registry.go
+++ b/controlplane/trino_registry.go
@@ -19,20 +19,41 @@ import (
 )
 
 const envTrinoCellsFile = "DUCKGRES_TRINO_CELLS_FILE"
+const envTrinoRegistryOnly = "DUCKGRES_TRINO_REGISTRY_ONLY"
 
 const registeredTrinoCellPrefix = "registered:"
 
-// resolveTrinoCells extends the legacy configuration without changing its ownership.
+// resolveTrinoCells preserves legacy unless registry-only mode explicitly excludes it.
 func resolveTrinoCells() ([]trinoCell, error) {
-	legacy, err := resolveTrinoCell()
-	if err != nil {
-		return nil, err
+	registryOnly := false
+	if value := strings.TrimSpace(os.Getenv(envTrinoRegistryOnly)); value != "" {
+		var err error
+		registryOnly, err = strconv.ParseBool(value)
+		if err != nil {
+			return nil, fmt.Errorf("%s must be a boolean", envTrinoRegistryOnly)
+		}
 	}
-	if strings.HasPrefix(legacy.ID, registeredTrinoCellPrefix) {
-		return nil, errors.New("legacy Trino cell ID uses the reserved registered prefix")
-	}
-	cells := []trinoCell{legacy}
 	path := strings.TrimSpace(os.Getenv(envTrinoCellsFile))
+	var legacy trinoCell
+	var cells []trinoCell
+	if registryOnly {
+		if path == "" {
+			return nil, fmt.Errorf("%s requires %s", envTrinoRegistryOnly, envTrinoCellsFile)
+		}
+		if strings.TrimSpace(os.Getenv(envTrinoCoordinatorURL)) != "" {
+			return nil, fmt.Errorf("%s cannot be combined with %s", envTrinoRegistryOnly, envTrinoCoordinatorURL)
+		}
+	} else {
+		var err error
+		legacy, err = resolveTrinoCell()
+		if err != nil {
+			return nil, err
+		}
+		if strings.HasPrefix(legacy.ID, registeredTrinoCellPrefix) {
+			return nil, errors.New("legacy Trino cell ID uses the reserved registered prefix")
+		}
+		cells = append(cells, legacy)
+	}
 	if path == "" {
 		return cells, nil
 	}
@@ -48,18 +69,21 @@ func resolveTrinoCells() ([]trinoCell, error) {
 	if legacyNS == "" {
 		legacyNS = provisioner.TrinoCustomerNamespace
 	}
-	legacyEndpoint, err := trinoEndpointKey(legacy.CoordinatorURL)
-	if err != nil {
-		return nil, fmt.Errorf("legacy coordinator URL: %w", err)
+	var legacyEndpoint string
+	if !registryOnly {
+		legacyEndpoint, err = trinoEndpointKey(legacy.CoordinatorURL)
+		if err != nil {
+			return nil, fmt.Errorf("legacy coordinator URL: %w", err)
+		}
 	}
 	for _, entry := range registered {
-		if entry.Namespace == legacyNS {
+		if !registryOnly && entry.Namespace == legacyNS {
 			return nil, errors.New("registered cell must not share the legacy namespace")
 		}
 		cell := trinoCell{ID: registeredTrinoCellPrefix + entry.ID, PublicID: entry.ID, Namespace: entry.Namespace, ClientURL: entry.ClientURL, Backends: entry.Backends}
 		for _, backend := range entry.Backends {
 			endpoint, _ := trinoEndpointKey(backend.CoordinatorURL)
-			if endpoint == legacyEndpoint {
+			if !registryOnly && endpoint == legacyEndpoint {
 				return nil, errors.New("registered cell must not share a legacy coordinator")
 			}
 			if backend.RoutingActive {

--- a/controlplane/trino_registry_test.go
+++ b/controlplane/trino_registry_test.go
@@ -39,6 +39,52 @@ func TestTrinoRegistryRuntimePreservesLegacyAndSkipsStoppedBackend(t *testing.T)
 
 const testTrinoRegistryJSON = `{"cells":[{"id":"cell-test","namespace":"trino-test","client_url":"https://gateway.example.test","routing_group":"cell-test","backends":[{"id":"blue","coordinator_url":"https://blue.example.test","running":true,"routing_active":true,"internal_secret_name":"blue-internal"},{"id":"green","coordinator_url":"https://green.example.test","running":false,"routing_active":false,"internal_secret_name":"green-internal"}]}]}`
 
+func TestTrinoRegistryOnlyRequiresExplicitValidConfiguration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cells.json")
+	if err := os.WriteFile(path, []byte(testTrinoRegistryJSON), 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, mode, url, file string
+		valid                 bool
+	}{
+		{"explicit", "true", "", path, true},
+		{"default still requires legacy", "", "", path, false},
+		{"disabled still requires legacy", "false", "", path, false},
+		{"mixed", "true", "https://legacy.example.test", path, false},
+		{"missing registry", "true", "", "", false},
+		{"unreadable registry", "true", "", path + "-missing", false},
+		{"invalid boolean", "invalid", "", path, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DUCKGRES_TRINO_REGISTRY_ONLY", tc.mode)
+			t.Setenv(envTrinoCoordinatorURL, tc.url)
+			t.Setenv(envTrinoCellsFile, tc.file)
+			if !trinoProvisionerEnabled() {
+				t.Fatal("explicit or invalid Trino configuration must reach startup validation")
+			}
+			cells, err := resolveTrinoCells()
+			if (err == nil) != tc.valid {
+				t.Fatalf("valid=%v error=%v", tc.valid, err)
+			}
+			if tc.valid && (len(cells) != 1 || cells[0].PublicID != "cell-test" || cells[0].ID != "registered:cell-test") {
+				t.Fatalf("unexpected registry-only fleet: %+v", cells)
+			}
+		})
+	}
+}
+
+func TestTrinoRegistryOnlyDisabledLeavesUnconfiguredDeploymentOff(t *testing.T) {
+	t.Setenv(envTrinoCoordinatorURL, "")
+	t.Setenv(envTrinoCellsFile, "")
+	for _, value := range []string{"", "false", "0"} {
+		t.Setenv(envTrinoRegistryOnly, value)
+		if trinoProvisionerEnabled() {
+			t.Fatalf("disabled mode %q unexpectedly enabled Trino", value)
+		}
+	}
+}
+
 func TestTrinoRegistryPreservesStoppedBackend(t *testing.T) {
 	cells, err := parseTrinoCellRegistry([]byte(testTrinoRegistryJSON))
 	if err != nil {

--- a/docs/trino-cells.md
+++ b/docs/trino-cells.md
@@ -15,6 +15,12 @@ Keep the existing `DUCKGRES_TRINO_COORDINATOR_URL`, namespace, TLS name, and cel
 ID unchanged; they continue to describe legacy. A registry without a legacy
 coordinator is rejected, rather than silently abandoning existing warehouses.
 
+For a deployment that has no legacy coordinator, explicitly set
+`DUCKGRES_TRINO_REGISTRY_ONLY=true` (default `false`). This requires a nonempty,
+valid `DUCKGRES_TRINO_CELLS_FILE` and rejects a configured legacy coordinator
+URL. It bootstraps only registered cells and exposes no legacy bundle endpoint.
+Existing legacy ownership is never reinterpreted or migrated.
+
 ```json
 {
   "cells": [
@@ -75,8 +81,17 @@ Use the authenticated operator console to select a cell **before first enabling
 Trino**, or use its admin-only `PUT /api/v1/orgs/<org>/trino/cell` endpoint with
 `{"cell":"cell-001"}`. Selection itself does not enable Trino. Unselected new
 warehouses retain the existing default: legacy claims them when enabled.
+In registry-only mode there is no default placement: both enablement endpoints
+reject an unassigned warehouse with "select an initial Trino cell before
+enabling Trino". Provision without Trino, select the initial cell, then enable.
+Already-enabled unassigned rows remain unprovisioned; disable them before
+initial selection. Unknown stored ownership fails closed without mutation.
 Assignments survive disable/re-enable. Already owned warehouses cannot change
 cells through this endpoint, even when disabled.
+
+Operational API calls require `?cell=<logical-id>` when no legacy cell exists.
+The Trino pages provide an explicit cell selector; they never select an arbitrary
+registered cell. The legacy default remains unchanged when legacy is configured.
 
 `client_url` is the opaque client endpoint, not a cell-selection instruction to
 customers. This PR does not implement authenticated Gateway assignment lookup.

--- a/justfile
+++ b/justfile
@@ -331,7 +331,7 @@ test-configstore-integration:
 # Run Kubernetes-only control plane package tests
 [group('test')]
 test-trino pattern="Trino":
-    go test -v -count=1 -tags kubernetes -run '{{pattern}}' ./controlplane ./controlplane/admin ./controlplane/provisioner
+    go test -v -count=1 -tags kubernetes -run '{{pattern}}' ./controlplane ./controlplane/admin ./controlplane/provisioner ./controlplane/provisioning
 
 [group('test')]
 test-controlplane-k8s:

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -542,6 +542,16 @@ queries the same data through green's independently hydrated catalog. Direct
 coordinator URLs are fixture-only; this does not test Gateway routing or a
 maintenance move of an existing warehouse.
 
+After these checks, the lane restarts its control plane in registry-only mode,
+verifies both registered backends still query the warehouse, rejects legacy
+ownership and implicit cell selection, and verifies the legacy bundle endpoint
+is absent. It restores the original configuration on success. Workflow teardown
+removes the disposable namespaces on failure, including during this phase.
+The registry-only phase also checks enablement admission for existing registered
+and legacy-owned warehouses. Initial assignment without a legacy default is
+covered by startup, admin, provisioning, and projection package tests; the
+real initial-placement flow runs earlier while both cells are configured.
+
 The fixture preserves the existing CI network-policy posture. It does not
 create network policies or add cluster-wide RBAC grants. Isolation assertions
 cover application authentication and OPA authorization, not network isolation.

--- a/tests/mw-dev/e2e/trino-multicell.sh
+++ b/tests/mw-dev/e2e/trino-multicell.sh
@@ -122,3 +122,46 @@ TRINO="$BLUE_TRINO"
 TRINO="$LEGACY_TRINO"
 [ "$(trino_query "$DB_A" "$pw_a" 'SELECT 1')" = '[[1]]' ] || fail "legacy failed during green hydration"
 log "PASS: initial placement + stopped green + isolated credentials/OPA + real DuckLake queries + green hydration"
+
+log "registry-only startup without legacy"
+legacy_env="$("$KUBECTL" -n "$NS" get deployment duckgres-control-plane -o json | jq -c '.spec.template.spec.containers[] | select(.name == "controlplane") | .env[] | select(.name == "DUCKGRES_TRINO_COORDINATOR_URL")')"
+[ -n "$legacy_env" ] || fail "missing legacy configuration before registry-only test"
+legacy_owner="$(api "$API/api/v1/orgs/$ORG_A" | jq -r .trino.trino_cell_id)"
+"$KUBECTL" -n "$NS" patch deployment duckgres-control-plane --type=strategic -p \
+  '{"spec":{"template":{"spec":{"containers":[{"name":"controlplane","env":[{"name":"DUCKGRES_TRINO_COORDINATOR_URL","$patch":"delete"},{"name":"DUCKGRES_TRINO_REGISTRY_ONLY","value":"true"}]}]}}}}' >/dev/null
+"$KUBECTL" -n "$NS" rollout status deployment/duckgres-control-plane --timeout=180s >/dev/null
+api "$API/api/v1/trino/cells" | jq -e '.cells | map(.id) == ["cell-test"]' >/dev/null \
+  || fail "registry-only startup invented a legacy cell"
+wait_cell_ready
+for endpoint in "$BLUE_TRINO" "$GREEN_TRINO"; do
+  TRINO="$endpoint"
+  [ "$(trino_query "$DB_C" "$pw_c" "SELECT COUNT(*), SUM(value) FROM $CAT_C.cell_test.values_test")" = '[[2,18]]' ] \
+    || fail "registry-only registered query failed"
+done
+code="$(curl --connect-timeout 5 --max-time 30 -sS -o /dev/null -w '%{http_code}' -H "$H" -H 'Content-Type: application/json' \
+  -X POST -d '{"enabled":true,"tier":"free"}' "$API/api/v1/orgs/$ORG_A/trino")"
+[ "$code" = 409 ] || fail "registry-only enablement accepted legacy ownership"
+api -X POST -H 'Content-Type: application/json' -d '{"enabled":true,"tier":"free"}' "$API/api/v1/orgs/$ORG_C/trino" >/dev/null
+for endpoint in "/api/v1/orgs/$ORG_A/trino" "/api/v1/trino/status"; do
+  code="$(curl --connect-timeout 5 --max-time 30 -sS -o /dev/null -w '%{http_code}' -H "$H" "$API$endpoint")"
+  if [ "$endpoint" = "/api/v1/trino/status" ]; then
+    [ "$code" = 400 ] || fail "registry-only implicitly selected a cell"
+  else
+    [ "$code" = 409 ] || fail "registry-only exposed legacy-owned warehouse"
+  fi
+done
+code="$(curl --connect-timeout 5 --max-time 30 -sS -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $cell_token" "$API/bundles/trino")"
+[ "$code" = 404 ] || fail "registry-only exposed legacy bundle endpoint"
+api "$API/api/v1/orgs/$ORG_A" | jq -e --arg owner "$legacy_owner" '.trino.trino_cell_id == $owner' >/dev/null \
+  || fail "registry-only changed legacy ownership"
+api "$API/api/v1/orgs/ci-pr-$PR-unassigned/trino" \
+  | jq -e '.assigned == false and .enabled == false and .available == false and .cell.id == ""' >/dev/null \
+  || fail "registry-only initial selection required but not accessible"
+
+log "restore legacy fixture configuration"
+patch="$(printf %s "$legacy_env" | jq -c '{spec:{template:{spec:{containers:[{name:"controlplane",env:[.,{name:"DUCKGRES_TRINO_REGISTRY_ONLY","$patch":"delete"}]}]}}}}')"
+"$KUBECTL" -n "$NS" patch deployment duckgres-control-plane --type=strategic -p "$patch" >/dev/null
+"$KUBECTL" -n "$NS" rollout status deployment/duckgres-control-plane --timeout=180s >/dev/null
+TRINO="$LEGACY_TRINO"
+[ "$(trino_query "$DB_A" "$pw_a" 'SELECT 1')" = '[[1]]' ] || fail "legacy query failed after registry-only fixture restore"
+log "PASS: registry-only startup + explicit selection + no legacy dependency + restored fixture"

--- a/tests/mw-dev/trino_multicell_test.go
+++ b/tests/mw-dev/trino_multicell_test.go
@@ -38,6 +38,24 @@ func TestTrinoMulticellFixtureKeepsIndependentBackendState(t *testing.T) {
 	}
 }
 
+func TestTrinoRegistryOnlyHarnessFollowsLegacyCompatibility(t *testing.T) {
+	raw, err := os.ReadFile("e2e/trino-multicell.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	phase := strings.Index(text, `log "registry-only startup without legacy"`)
+	compat := strings.Index(text, `legacy failed during green hydration`)
+	if phase < compat || compat < 0 {
+		t.Fatal("registry-only phase must follow legacy and green validation")
+	}
+	for _, want := range []string{`DUCKGRES_TRINO_REGISTRY_ONLY`, `DUCKGRES_TRINO_COORDINATOR_URL`, `"$code" = 409`, `"$code" = 404`, `registry-only registered query failed`, `restore legacy fixture configuration`, `registry-only initial selection required`} {
+		if !strings.Contains(text, want) {
+			t.Errorf("missing registry-only E2E contract %q", want)
+		}
+	}
+}
+
 func TestTrinoMulticellRenderedBackendsAreIsolated(t *testing.T) {
 	envsubst, err := exec.LookPath("envsubst")
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add explicit `DUCKGRES_TRINO_REGISTRY_ONLY=true` support for deployments with registered cells and no legacy coordinator. The default still rejects a missing legacy URL; registry-only mode requires a valid registry and rejects mixed configuration.
- Require explicit initial placement before enablement in registry-only mode. Preserve existing ownership and legacy defaults; never assign an arbitrary registered cell or reinterpret legacy rows.
- Expose safe unassigned status and an explicit cell picker on operational Trino pages. No warehouse migration or Gateway routing changes.

## Validation

- Red/green startup, admin and enablement regressions.
- `just test-trino`, `just test-controlplane-k8s`, `just test-mw-fixtures`, `just ui-test` (195 tests), and `just lint` pass locally.
- Independent adversarial review completed.
- The first live run passed legacy compatibility, initial placement, tenant isolation and green hydration. Its registry-only phase found a fixture Service-convergence race after restart; bounded registry checks and behavioral regression tests now cover that transition.
- The isolated Trino CI lane now restarts its control plane in registry-only mode after existing legacy/multicell checks, verifies both registered backends, legacy-owner rejection, and absence of the legacy bundle route, then restores its fixture.

Draft until the extended live Trino CI lane passes. This does not alter a shared deployment.
