### PR TITLE
feat(admin): configure Trino at the top of org settings

### DIFF
--- a/controlplane/admin/README.md
+++ b/controlplane/admin/README.md
@@ -202,7 +202,7 @@ routes accept `?cell=<logical-id>` and default to `legacy`. Org detail resolves
 its authoritative stored assignment regardless of a supplied cell parameter.
 Each coordinator has separate caches; tenant counts include only its cell.
 
-Admins can select an initial cell in the org's Trino card or send
+Admins can select an initial cell at the top of **Org configuration** or send
 `PUT /api/v1/orgs/:id/trino/cell` with `{"cell":"cell-001"}`. This stores a
 disabled assignment before the normal enable endpoint is called. The warehouse
 must already exist. Selection does not enable Trino or move an existing tenant.
@@ -211,6 +211,20 @@ selection of the same assignment is idempotent. An enabled unassigned row also
 rejects selection because its first provisioning tick may already be running.
 On a 409, inspect the current assignment rather than editing its database row.
 Moving an existing tenant requires a separate maintenance/drain workflow.
+
+The Trino section has separate **Select cell**, **Enable Trino**, and
+**Disable Trino** actions. These do not submit the other org configuration
+fields. The UI requires a saved assignment before enabling and preserves the
+stored resource-group tier when re-enabling. Selection alone never enables
+Trino; disabling retains the assignment and is not a maintenance barrier.
+Viewers can read the configuration but cannot change it. The lower Trino card
+continues to show provisioning status and live query counts.
+
+Enablement uses the existing same-origin POST/DELETE `/api/v1/orgs/:id/trino`
+routes, protected by the shared admin authentication, role gate, and audit
+middleware. The browser receives no provisioning token. Vitest covers these
+UI actions and request shapes; the isolated Trino suite exercises the unchanged
+enable/disable endpoints against real infrastructure.
 
 For newly registered cells, configure the shared customer endpoint separately
 from the observer coordinator URL. This API does not configure Gateway routing.

--- a/controlplane/admin/ui/src/hooks/useApi.ts
+++ b/controlplane/admin/ui/src/hooks/useApi.ts
@@ -858,6 +858,16 @@ export function useSelectTrinoCell() {
   });
 }
 
+export function useSetTrinoEnabled() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ org, enabled, tier }: { org: string; enabled: boolean; tier: string }) =>
+      enabled ? api.enableTrino(org, tier) : api.disableTrino(org),
+    // Refresh authoritative state after errors too: a timed-out write can commit.
+    onSettled: () => qc.invalidateQueries({ queryKey: ["trino"] }),
+  });
+}
+
 export function useKillTrinoQuery(cell?: string) {
   const qc = useQueryClient();
   return useMutation({

--- a/controlplane/admin/ui/src/hooks/useTrinoEnablement.test.tsx
+++ b/controlplane/admin/ui/src/hooks/useTrinoEnablement.test.tsx
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { api } from "@/lib/api";
+import { useSetTrinoEnabled } from "./useApi";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/lib/api")>();
+  return { ...mod, api: { ...mod.api, enableTrino: vi.fn(), disableTrino: vi.fn() } };
+});
+
+describe("Trino enablement mutation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each([true, false])("sends enabled=%s and refreshes Trino without discarding the org form", async (enabled) => {
+    vi.mocked(api.enableTrino).mockResolvedValue({ status: "queued", org: "org-a" });
+    vi.mocked(api.disableTrino).mockResolvedValue({ status: "queued", org: "org-a" });
+    const client = new QueryClient();
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+    const { result } = renderHook(() => useSetTrinoEnabled(), { wrapper });
+    await act(async () => { await result.current.mutateAsync({ org: "org-a", enabled, tier: "premium" }); });
+    if (enabled) expect(api.enableTrino).toHaveBeenCalledWith("org-a", "premium");
+    else expect(api.disableTrino).toHaveBeenCalledWith("org-a");
+    expect(invalidate.mock.calls).toEqual([[{ queryKey: ["trino"] }]]);
+  });
+
+  it("refreshes authoritative state after a failed request without automatic retry", async () => {
+    vi.mocked(api.enableTrino).mockRejectedValue(new Error("Timed out"));
+    const client = new QueryClient();
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+    const wrapper = ({ children }: { children: ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+    const { result } = renderHook(() => useSetTrinoEnabled(), { wrapper });
+    await act(async () => {
+      await expect(result.current.mutateAsync({ org: "org-a", enabled: true, tier: "" })).rejects.toThrow("Timed out");
+    });
+    expect(api.enableTrino).toHaveBeenCalledTimes(1);
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["trino"] });
+  });
+});

--- a/controlplane/admin/ui/src/lib/api.trino.test.ts
+++ b/controlplane/admin/ui/src/lib/api.trino.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api } from "./api";
+
+describe("Trino enablement API", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("uses same-origin authenticated routes and preserves the selected tier", async () => {
+    const fetch = vi.fn().mockImplementation(async () => new Response('{"status":"queued"}', { status: 202 }));
+    vi.stubGlobal("fetch", fetch);
+    await api.enableTrino("org/a", "premium");
+    expect(fetch).toHaveBeenCalledWith("/api/v1/orgs/org%2Fa/trino", expect.objectContaining({
+      method: "POST", body: '{"enabled":true,"tier":"premium"}',
+      headers: { Accept: "application/json", "Content-Type": "application/json" },
+    }));
+    await api.disableTrino("org/a");
+    expect(fetch).toHaveBeenLastCalledWith("/api/v1/orgs/org%2Fa/trino", expect.objectContaining({
+      method: "DELETE", headers: { Accept: "application/json" },
+    }));
+  });
+});

--- a/controlplane/admin/ui/src/lib/api.ts
+++ b/controlplane/admin/ui/src/lib/api.ts
@@ -316,4 +316,8 @@ export const api = {
   trinoCells: () => get<{ cells: TrinoCell[] }>("/trino/cells"),
   selectTrinoCell: (org: string, cell: string) =>
     put<{ cell: TrinoCell; assigned: boolean }>(`/orgs/${enc(org)}/trino/cell`, { cell }),
+  enableTrino: (org: string, tier: string) =>
+    post<{ status: string; org: string }>(`/orgs/${enc(org)}/trino`, { enabled: true, tier }),
+  disableTrino: (org: string) =>
+    del<{ status: string; org: string }>(`/orgs/${enc(org)}/trino`),
 };

--- a/controlplane/admin/ui/src/pages/OrgDetail.test.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.test.tsx
@@ -16,6 +16,10 @@ const hooks = vi.hoisted(() => ({
   useUpdateOrg: vi.fn(),
   useUpdateWarehouse: vi.fn(),
   useWarehouse: vi.fn(),
+  useOrgTrino: vi.fn(),
+  useTrinoCells: vi.fn(),
+  useSelectTrinoCell: vi.fn(),
+  useSetTrinoEnabled: vi.fn(),
 }));
 vi.mock("@/hooks/useApi", () => hooks);
 
@@ -44,6 +48,7 @@ vi.mock("@/pages/OrgTrinoCard", () => ({
 }));
 
 import { OrgDetail } from "./OrgDetail";
+
 
 const warehouseUpdate = vi.fn();
 const orgUpdate = vi.fn();
@@ -142,6 +147,10 @@ describe("Org detail", () => {
       me: { email: "admin@example.com", role: "admin", source: "sso" },
     });
     hooks.useOrg.mockReturnValue(ok(ORG));
+    hooks.useOrgTrino.mockReturnValue(ok({ enabled: false, assigned: false, cell: { id: "legacy" } }));
+    hooks.useTrinoCells.mockReturnValue(ok({ cells: [{ id: "legacy" }] }));
+    hooks.useSelectTrinoCell.mockReturnValue(mut());
+    hooks.useSetTrinoEnabled.mockReturnValue(mut());
     hooks.useDatabaseNameAvailable.mockReturnValue({ data: null, isLoading: false });
     hooks.useUpdateOrg.mockReturnValue(mut(orgUpdate));
     hooks.useDeleteOrg.mockReturnValue(mut());
@@ -150,6 +159,29 @@ describe("Org detail", () => {
     hooks.useDucklingsMetadata.mockReturnValue(ok({ available: true, entries: [] }));
     hooks.useOrgReshards.mockReturnValue(ok([]));
     hooks.useOrgTeams.mockReturnValue(ok([]));
+  });
+
+  it("places Trino controls before worker settings in org configuration", () => {
+    renderPage(false);
+    const config = screen.getByText("Org configuration").closest(".rounded-lg")!;
+    const trino = within(config as HTMLElement).getByText("Trino configuration");
+    const workers = within(config as HTMLElement).getByText("Max workers (0 = unbounded)");
+    expect(trino.compareDocumentPosition(workers) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("keeps unsaved org fields separate from an initial Trino selection", async () => {
+    const select = vi.fn().mockResolvedValue({ assigned: true });
+    hooks.useSelectTrinoCell.mockReturnValue(mut(select));
+    renderPage(false);
+    const user = userEvent.setup();
+    const database = screen.getByLabelText("Database name");
+    await user.clear(database);
+    await user.type(database, "pending-name");
+    await user.selectOptions(screen.getByLabelText("Initial Trino cell"), "legacy");
+    await user.click(screen.getByRole("button", { name: "Select cell" }));
+    expect(select).toHaveBeenCalledWith({ org: "acme", cell: "legacy" });
+    expect(orgUpdate).not.toHaveBeenCalled();
+    expect(database).toHaveValue("pending-name");
   });
 
   it("headline leads with the database name; the org id is a subline with a copy button", () => {

--- a/controlplane/admin/ui/src/pages/OrgDetail.tsx
+++ b/controlplane/admin/ui/src/pages/OrgDetail.tsx
@@ -29,6 +29,7 @@ import { CopyButton } from "@/components/CopyButton";
 import { ShardBadge } from "@/components/ShardBadge";
 import { OrgUsageSection } from "@/pages/OrgUsage";
 import { OrgTrinoCard } from "@/pages/OrgTrinoCard";
+import { OrgTrinoSettings } from "@/pages/OrgTrinoSettings";
 import {
   useDatabaseNameAvailable,
   useDeleteOrg,
@@ -250,6 +251,7 @@ export function OrgDetail() {
               </span>
             </CardHeader>
             <CardContent className="space-y-3">
+              <OrgTrinoSettings key={id} orgId={id} hasWarehouse={orgHasWarehouse} tier={org.data?.trino?.tier ?? ""} />
               <div className="grid grid-cols-2 gap-3">
                 <Field label="Max workers (0 = unbounded)">
                   <Input type="number" value={form.max_workers} onChange={(e) => set("max_workers", e.target.value)} />

--- a/controlplane/admin/ui/src/pages/OrgTrinoCard.test.tsx
+++ b/controlplane/admin/ui/src/pages/OrgTrinoCard.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import type { TrinoOrgDetail, TrinoOrgStatus } from "@/types/api";
 
@@ -53,30 +53,10 @@ describe("OrgTrinoCard", () => {
     identity.useIdentity.mockReturnValue({ isAdmin: true });
   });
 
-  it("lets an admin select an initial cell without enabling Trino", () => {
-    const mutate = vi.fn();
-    hooks.useOrgTrino.mockReturnValue(ok(detail({ enabled: false, assigned: false, status: undefined })));
-    hooks.useTrinoCells.mockReturnValue(ok({ cells: [{ id: "legacy" }, { id: "cell-001" }] }));
-    hooks.useSelectTrinoCell.mockReturnValue({ mutate, isPending: false });
-    renderCard();
-    fireEvent.change(screen.getByLabelText("Initial Trino cell"), { target: { value: "cell-001" } });
-    fireEvent.click(screen.getByRole("button", { name: "Select cell" }));
-    expect(mutate).toHaveBeenCalledWith({ org: "org-a", cell: "cell-001" });
-    expect(screen.getByText(/does not enable Trino/)).toBeInTheDocument();
-  });
-
-  it("keeps a disabled warehouse's assignment immutable", () => {
+  it("does not duplicate the configuration controls for a disabled assignment", () => {
     hooks.useOrgTrino.mockReturnValue(ok(detail({ enabled: false, assigned: true, status: undefined })));
-    renderCard();
-    expect(screen.getByText(/Assigned cell: legacy/)).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Select cell" })).not.toBeInTheDocument();
-  });
-
-  it("never offers selection to viewers", () => {
-    identity.useIdentity.mockReturnValue({ isAdmin: false });
-    hooks.useOrgTrino.mockReturnValue(ok(detail({ enabled: false, assigned: false, status: undefined })));
-    hooks.useTrinoCells.mockReturnValue(ok({ cells: [{ id: "legacy" }, { id: "cell-001" }] }));
-    renderCard();
+    const { container } = renderCard();
+    expect(container).toBeEmptyDOMElement();
     expect(screen.queryByRole("button", { name: "Select cell" })).not.toBeInTheDocument();
   });
 
@@ -85,14 +65,6 @@ describe("OrgTrinoCard", () => {
     renderCard();
     expect(screen.getByText(/Unknown assignment/)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Select cell" })).not.toBeInTheDocument();
-  });
-
-  it("shows a rejected selection without hiding the error", () => {
-    hooks.useOrgTrino.mockReturnValue(ok(detail({ enabled: false, assigned: false, status: undefined })));
-    hooks.useTrinoCells.mockReturnValue(ok({ cells: [{ id: "legacy" }] }));
-    hooks.useSelectTrinoCell.mockReturnValue({ mutate: vi.fn(), error: new Error("Assignment is immutable") });
-    renderCard();
-    expect(screen.getByRole("alert")).toHaveTextContent("Assignment is immutable");
   });
 
   it("renders nothing for an org that is not Trino-enabled", () => {

--- a/controlplane/admin/ui/src/pages/OrgTrinoCard.tsx
+++ b/controlplane/admin/ui/src/pages/OrgTrinoCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
 import { AlertTriangle, Sparkles } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -6,9 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { StateBadge } from "@/components/StateBadge";
 import { LoadingState } from "@/components/states";
 import { CopyButton } from "@/components/CopyButton";
-import { useOrgTrino, useTrinoCells, useSelectTrinoCell } from "@/hooks/useApi";
-import { useIdentity } from "@/components/IdentityProvider";
-import { Button } from "@/components/ui/button";
+import { useOrgTrino } from "@/hooks/useApi";
 import { fmtInt, fmtTime } from "@/lib/format";
 
 function Field({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
@@ -47,10 +44,7 @@ export function OrgTrinoCard({ orgId }: { orgId: string }) {
   if (trino.isError) {
     return <Card><CardContent className="pt-6 text-destructive">Cannot read Trino assignment. {trino.error?.message}</CardContent></Card>;
   }
-  if (!trino.data?.enabled) {
-    return <InitialCellSelection orgId={orgId} assigned={trino.data?.assigned ?? false} cell={trino.data?.cell.id ?? ""} />;
-  }
-  if (!trino.data.status) {
+  if (!trino.data?.enabled || !trino.data.status) {
     return null;
   }
 
@@ -120,31 +114,6 @@ export function OrgTrinoCard({ orgId }: { orgId: string }) {
         >
           View this cell&apos;s live queries →
         </Link>
-      </CardContent>
-    </Card>
-  );
-}
-
-function InitialCellSelection({ orgId, assigned, cell }: { orgId: string; assigned: boolean; cell: string }) {
-  const { isAdmin } = useIdentity();
-  const cells = useTrinoCells();
-  const selection = useSelectTrinoCell();
-  const [chosen, setChosen] = useState("");
-  if (assigned) {
-    return <Card><CardContent className="pt-6 text-sm">Assigned cell: {cell}. Trino is disabled. Existing assignments cannot be changed here.</CardContent></Card>;
-  }
-  if (!isAdmin || !cells.data?.cells.length) return null;
-  return (
-    <Card>
-      <CardHeader><CardTitle>Trino cell</CardTitle></CardHeader>
-      <CardContent className="space-y-3">
-        <p className="text-sm">Select the initial cell before enabling Trino. This does not enable Trino. The assignment cannot be changed here afterward.</p>
-        <select aria-label="Initial Trino cell" value={chosen} onChange={(event) => setChosen(event.target.value)} className="rounded border bg-background p-2 text-sm">
-          <option value="">Choose a cell</option>
-          {cells.data.cells.map((entry) => <option key={entry.id} value={entry.id}>{entry.id}</option>)}
-        </select>
-        <Button disabled={!chosen || selection.isPending} onClick={() => selection.mutate({ org: orgId, cell: chosen })}>Select cell</Button>
-        {selection.error && <p role="alert" className="text-sm text-destructive">{selection.error.message}</p>}
       </CardContent>
     </Card>
   );

--- a/controlplane/admin/ui/src/pages/OrgTrinoSettings.test.tsx
+++ b/controlplane/admin/ui/src/pages/OrgTrinoSettings.test.tsx
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const hooks = vi.hoisted(() => ({ useOrgTrino: vi.fn(), useTrinoCells: vi.fn(), useSelectTrinoCell: vi.fn(), useSetTrinoEnabled: vi.fn() }));
+vi.mock("@/hooks/useApi", () => hooks);
+const identity = vi.hoisted(() => ({ useIdentity: vi.fn() }));
+vi.mock("@/components/IdentityProvider", () => identity);
+import { OrgTrinoSettings } from "./OrgTrinoSettings";
+
+const select = vi.fn();
+const enable = vi.fn();
+const refetch = vi.fn();
+const ok = <T,>(data: T) => ({ data, isLoading: false, error: null, refetch });
+const details = (enabled = false, assigned = false) => ok({ enabled, assigned, cell: { id: "legacy" } });
+function renderSettings(hasWarehouse = true, tier = "premium") {
+  return render(<OrgTrinoSettings orgId="org-a" hasWarehouse={hasWarehouse} tier={tier} />);
+}
+
+describe("Org Trino configuration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    select.mockResolvedValue({ assigned: true });
+    enable.mockResolvedValue({ status: "queued" });
+    refetch.mockResolvedValue(undefined);
+    identity.useIdentity.mockReturnValue({ isAdmin: true });
+    hooks.useOrgTrino.mockReturnValue(details());
+    hooks.useTrinoCells.mockReturnValue(ok({ cells: [{ id: "legacy" }, { id: "cell-001" }] }));
+    hooks.useSelectTrinoCell.mockReturnValue({ mutateAsync: select, isPending: false });
+    hooks.useSetTrinoEnabled.mockReturnValue({ mutateAsync: enable, isPending: false });
+  });
+
+  it("requires an explicit saved selection before enabling and never enables on selection", async () => {
+    renderSettings();
+    expect(screen.getByRole("button", { name: "Enable Trino" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Select cell" })).toBeDisabled();
+    fireEvent.change(screen.getByLabelText("Initial Trino cell"), { target: { value: "cell-001" } });
+    fireEvent.click(screen.getByRole("button", { name: "Select cell" }));
+    await waitFor(() => expect(select).toHaveBeenCalledWith({ org: "org-a", cell: "cell-001" }));
+    expect(enable).not.toHaveBeenCalled();
+    expect(await screen.findByRole("status")).toHaveTextContent("Trino remains disabled");
+    expect(screen.getByRole("button", { name: "Enable Trino" })).toBeDisabled();
+  });
+
+  it("re-enables an assigned legacy warehouse without changing its tier or cell", async () => {
+    hooks.useOrgTrino.mockReturnValue(details(false, true));
+    renderSettings();
+    expect(screen.getByText("Cell: legacy")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Initial Trino cell")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Enable Trino" }));
+    await waitFor(() => expect(enable).toHaveBeenCalledWith({ org: "org-a", enabled: true, tier: "premium" }));
+    expect(select).not.toHaveBeenCalled();
+    expect(await screen.findByRole("status")).toHaveTextContent("Provisioning may take a moment");
+  });
+
+  it("offers explicit initial selection for a registry-only blank assignment", () => {
+    hooks.useOrgTrino.mockReturnValue(ok({ enabled: false, assigned: false, available: false, cell: { id: "", coordinator_url: "" } }));
+    hooks.useTrinoCells.mockReturnValue(ok({ cells: [{ id: "cell-test" }] }));
+    renderSettings();
+    expect(screen.getByText("Cell: Not selected")).toBeInTheDocument();
+    expect(screen.getByLabelText("Initial Trino cell")).toHaveValue("");
+    expect(screen.getByRole("button", { name: "Enable Trino" })).toBeDisabled();
+    expect(screen.queryByRole("option", { name: "legacy" })).not.toBeInTheDocument();
+  });
+
+  it("lets an enabled unassigned warehouse disable before selecting its initial cell", async () => {
+    hooks.useOrgTrino.mockReturnValue(ok({ enabled: true, assigned: false, available: false, cell: { id: "", coordinator_url: "" } }));
+    hooks.useTrinoCells.mockReturnValue(ok({ cells: [{ id: "cell-test" }] }));
+    renderSettings();
+    expect(screen.queryByLabelText("Initial Trino cell")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Disable Trino" }));
+    await waitFor(() => expect(enable).toHaveBeenCalledWith({ org: "org-a", enabled: false, tier: "premium" }));
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it("disables independently and does not offer a move", async () => {
+    hooks.useOrgTrino.mockReturnValue(details(true, true));
+    renderSettings();
+    fireEvent.click(screen.getByRole("button", { name: "Disable Trino" }));
+    await waitFor(() => expect(enable).toHaveBeenCalledWith({ org: "org-a", enabled: false, tier: "premium" }));
+    expect(select).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText("Initial Trino cell")).not.toBeInTheDocument();
+    expect(await screen.findByRole("status")).toHaveTextContent("Access is removed during reconciliation");
+  });
+
+  it("retains selection errors and refreshes after an ambiguous write", async () => {
+    select.mockRejectedValue(new Error("Assignment is immutable"));
+    renderSettings();
+    fireEvent.change(screen.getByLabelText("Initial Trino cell"), { target: { value: "cell-001" } });
+    fireEvent.click(screen.getByRole("button", { name: "Select cell" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Assignment is immutable");
+    expect(enable).not.toHaveBeenCalled();
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it("shows enable errors without pretending Trino is enabled", async () => {
+    hooks.useOrgTrino.mockReturnValue(details(false, true));
+    enable.mockRejectedValue(new Error("Root user is missing"));
+    renderSettings();
+    fireEvent.click(screen.getByRole("button", { name: "Enable Trino" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Root user is missing");
+    expect(screen.getByText("Disabled")).toBeInTheDocument();
+  });
+
+  it.each(["selection", "enablement"])("blocks changes while %s is pending", (pending) => {
+    if (pending === "selection") hooks.useSelectTrinoCell.mockReturnValue({ mutateAsync: select, isPending: true });
+    else hooks.useSetTrinoEnabled.mockReturnValue({ mutateAsync: enable, isPending: true });
+    renderSettings();
+    for (const button of screen.getAllByRole("button")) expect(button).toBeDisabled();
+    expect(screen.getByLabelText("Initial Trino cell")).toBeDisabled();
+  });
+
+  it("renders read-only configuration for viewers", () => {
+    identity.useIdentity.mockReturnValue({ isAdmin: false });
+    hooks.useOrgTrino.mockReturnValue(details(true, true));
+    renderSettings();
+    expect(screen.getByText("Cell: legacy")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it.each(["assignment", "cells"])("fails closed when %s cannot be read", (failed) => {
+    (failed === "assignment" ? hooks.useOrgTrino : hooks.useTrinoCells).mockReturnValue({ error: new Error("Unavailable") });
+    renderSettings();
+    expect(screen.getByRole("alert")).toHaveTextContent("Unavailable");
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("reports an environment without Trino and makes no writes", () => {
+    hooks.useTrinoCells.mockReturnValue(ok({ cells: [] }));
+    renderSettings();
+    expect(screen.getByText("Trino is not configured in this environment.")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("requires a warehouse before selection or enablement", () => {
+    renderSettings(false);
+    expect(screen.getByLabelText("Initial Trino cell")).toBeDisabled();
+    for (const button of screen.getAllByRole("button")) expect(button).toBeDisabled();
+  });
+
+  it("shows loading before offering controls", () => {
+    hooks.useOrgTrino.mockReturnValue({ isLoading: true });
+    renderSettings();
+    expect(screen.getByText("Loading Trino configuration…")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/controlplane/admin/ui/src/pages/OrgTrinoSettings.tsx
+++ b/controlplane/admin/ui/src/pages/OrgTrinoSettings.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import { useIdentity } from "@/components/IdentityProvider";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useOrgTrino, useSelectTrinoCell, useSetTrinoEnabled, useTrinoCells } from "@/hooks/useApi";
+
+export function OrgTrinoSettings({ orgId, hasWarehouse, tier }: {
+  orgId: string;
+  hasWarehouse: boolean;
+  tier: string;
+}) {
+  const { isAdmin } = useIdentity();
+  const trino = useOrgTrino(orgId);
+  const cells = useTrinoCells();
+  const selection = useSelectTrinoCell();
+  const enablement = useSetTrinoEnabled();
+  const [chosen, setChosen] = useState("");
+  const [message, setMessage] = useState<{ error: boolean; text: string } | null>(null);
+  const busy = selection.isPending || enablement.isPending;
+  const assigned = trino.data?.assigned === true;
+  const enabled = trino.data?.enabled === true;
+
+  async function selectCell() {
+    setMessage(null);
+    try {
+      await selection.mutateAsync({ org: orgId, cell: chosen });
+      setMessage({ error: false, text: "Cell selected. Trino remains disabled; enable it separately when ready." });
+    } catch (error) {
+      setMessage({ error: true, text: error instanceof Error ? error.message : "Cell selection failed." });
+      await trino.refetch();
+    }
+  }
+
+  async function setEnabled() {
+    setMessage(null);
+    try {
+      await enablement.mutateAsync({ org: orgId, enabled: !enabled, tier });
+      setMessage({ error: false, text: enabled ? "Disable requested. Access is removed during reconciliation." : "Enable requested. Provisioning may take a moment." });
+    } catch (error) {
+      setMessage({ error: true, text: error instanceof Error ? error.message : "Trino update failed." });
+    }
+  }
+
+  const error = trino.error || cells.error;
+  let content;
+  if (trino.isLoading || cells.isLoading) {
+    content = <p className="text-xs text-muted-foreground">Loading Trino configuration…</p>;
+  } else if (error) {
+    content = <p role="alert" className="text-xs text-destructive">Cannot read Trino configuration. {error.message}</p>;
+  } else if (!cells.data?.cells.length) {
+    content = <p className="text-xs text-muted-foreground">Trino is not configured in this environment.</p>;
+  } else {
+    content = <>
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        <Badge variant="outline">{enabled ? "Enabled" : "Disabled"}</Badge>
+        <span>Cell: {assigned ? trino.data?.cell.id : "Not selected"}</span>
+      </div>
+      {assigned ? (
+        <p className="text-xs text-muted-foreground">The assigned cell cannot change here, including while Trino is disabled.</p>
+      ) : (
+        <p className="text-xs text-muted-foreground">Select an initial cell before enabling Trino. Selection is permanent here and does not enable Trino.</p>
+      )}
+      {!hasWarehouse && <p className="text-xs text-muted-foreground">Provision a warehouse before selecting a cell or enabling Trino.</p>}
+      {isAdmin && <div className="flex flex-wrap items-center gap-2">
+        {!assigned && !enabled && <>
+          <select aria-label="Initial Trino cell" value={chosen} disabled={busy || !hasWarehouse}
+            onChange={(event) => setChosen(event.target.value)} className="rounded border bg-background p-2 text-sm">
+            <option value="">Choose a cell</option>
+            {cells.data.cells.map((cell) => <option key={cell.id} value={cell.id}>{cell.id}</option>)}
+          </select>
+          <Button size="sm" disabled={busy || !hasWarehouse || !cells.data.cells.some((cell) => cell.id === chosen)} onClick={selectCell}>
+            {selection.isPending ? "Selecting…" : "Select cell"}
+          </Button>
+        </>}
+        <Button size="sm" variant={enabled ? "outline" : "default"}
+          disabled={busy || (!enabled && (!assigned || !hasWarehouse))} onClick={setEnabled}>
+          {enablement.isPending ? "Updating Trino…" : enabled ? "Disable Trino" : "Enable Trino"}
+        </Button>
+      </div>}
+      <p className="text-xs text-muted-foreground">Trino actions apply separately from Save changes. Disabling does not move the warehouse or establish a maintenance barrier.</p>
+    </>;
+  }
+
+  return <section aria-label="Trino configuration" className="space-y-2 border-b pb-4">
+    <h3 className="text-sm font-medium">Trino configuration</h3>
+    {content}
+    {message && <p role={message.error ? "alert" : "status"} className={`text-xs ${message.error ? "text-destructive" : "text-muted-foreground"}`}>{message.text}</p>}
+  </section>;
+}

--- a/controlplane/admin/ui/src/types/api.ts
+++ b/controlplane/admin/ui/src/types/api.ts
@@ -59,6 +59,7 @@ export interface Org {
   data_imports_table_naming_version: DataImportsTableNamingVersion;
   users?: OrgUser[];
   warehouse?: ManagedWarehouse | null;
+  trino?: { enabled: boolean; tier: string; trino_cell_id: string } | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary

- Put Trino configuration first in the org configuration card, with separate **Select cell**, **Enable Trino**, and **Disable Trino** actions.
- Require an explicit saved initial assignment before enabling. Preserve existing assignments and resource-group tiers, including while disabled.
- Reuse the authenticated, admin-only, audited enable/disable endpoints. No provisioning token is exposed to the browser.
- Keep other unsaved org fields untouched by Trino actions. Retain the lower Trino card for provisioning status and live query counts.

This does not implement warehouse moves, maintenance barriers, or Gateway routing. Disabling Trino remains asynchronous reconciliation, not proof that all work has drained.

## Validation

- TDD: new top-of-configuration placement test failed before implementation, then passed.
- `just ui-test`: typecheck, 210 tests, and production build passed.
- `just lint`: passed with zero issues.
- Coverage includes read-only viewers, immutable assignments, saved selection before enable, preserved tier, pending/error states, ambiguous writes, unconfigured environments, registry-only unassigned recovery, request shapes, and unsaved general org fields.
- Independent agent review completed; no blocking findings. Added the review's registry-only regression cases.

UI-only change over existing backend endpoints. No live warehouse settings were changed during development.
