### PR TITLE
build: pull MinIO from quay.io instead of Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,12 +189,14 @@ jobs:
 
       - name: Create MinIO bucket
         run: |
-          # Install mc client
-          curl -sL https://dl.min.io/client/mc/release/linux-arm64/mc -o /tmp/mc
-          chmod +x /tmp/mc
-          # Configure and create bucket
-          /tmp/mc alias set minio http://localhost:39000 minioadmin minioadmin
-          /tmp/mc mb minio/ducklake --ignore-existing
+          # dl.min.io returns 410 Gone: MinIO archived the community mc client
+          # alongside the Docker Hub images. Run mc from its quay.io image
+          # instead. `--network container:minio` joins MinIO's own namespace,
+          # so the endpoint is its internal port, not the published one.
+          docker run --rm --network container:minio \
+            -e MC_HOST_minio=http://minioadmin:minioadmin@localhost:9000 \
+            quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z \
+            mb minio/ducklake --ignore-existing
 
       - name: Run integration tests
         run: just test-integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,11 +175,12 @@ jobs:
 
       - name: Start MinIO
         run: |
+          # MinIO deleted its Docker Hub repositories; quay.io is the live source.
           docker run -d --name minio \
             -p 39000:9000 \
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
-            quay.io/minio/minio:latest server /data
+            quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
           # Wait for MinIO to be ready
           for i in {1..30}; do
             curl -sf http://localhost:39000/minio/health/live && break

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,9 @@ services:
       retries: 5
 
   minio:
-    image: minio/minio:latest
+    # MinIO deleted its Docker Hub repositories, so pull from quay.io. The tag is a
+    # dated release rather than `latest` so a rebuild cannot silently change it.
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: ducklake-storage
     command: server /data --console-address ":9001"
     environment:
@@ -36,7 +38,7 @@ services:
 
   # Creates the ducklake bucket on startup
   minio-init:
-    image: minio/mc:latest
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     container_name: ducklake-storage-init
     depends_on:
       minio:

--- a/k8s/local-config-store.compose.yaml
+++ b/k8s/local-config-store.compose.yaml
@@ -47,7 +47,9 @@ services:
       - /var/lib/postgresql/data
 
   minio:
-    image: minio/minio:latest
+    # MinIO deleted its Docker Hub repositories, so pull from quay.io. The tag is a
+    # dated release rather than `latest` so a rebuild cannot silently change it.
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: duckgres-local-minio
     command: server /data --console-address ":9001"
     environment:

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -42,7 +42,9 @@ services:
 
   # MinIO for DuckLake object storage
   minio:
-    image: minio/minio:latest
+    # MinIO deleted its Docker Hub repositories, so pull from quay.io. The tag is a
+    # dated release rather than `latest` so a rebuild cannot silently change it.
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: duckgres-test-minio
     command: server /data --console-address ":9001"
     environment:
@@ -61,7 +63,7 @@ services:
 
   # Creates the ducklake bucket on startup
   minio-init:
-    image: minio/mc:latest
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     container_name: duckgres-test-minio-init
     depends_on:
       minio:


### PR DESCRIPTION
## Summary

- Point every `minio/minio` and `minio/mc` reference at `quay.io`
- Pin dated release tags instead of `latest`
- Run `mc` from its image, replacing the `dl.min.io` download that now 410s

## Why

MinIO deleted its Docker Hub repositories. This is not a rate limit and not an auth problem, despite the error text:

```
docker: Error response from daemon: pull access denied for minio/minio,
repository does not exist or may require 'docker login'
```

The Hub API agrees they are gone:

```
https://hub.docker.com/v2/repositories/minio/minio/  -> 404 {"message":"object not found"}
https://hub.docker.com/v2/repositories/minio/mc/     -> 404
quay.io/minio/minio -> 200      quay.io/minio/mc -> 200
```

This currently turns `controlplane-tests` and `integration-tests` red on every branch.

The client binary is gone too. `https://dl.min.io/client/mc/release/linux-arm64/mc` returns **410 Gone**:

> The open-source MinIO Server, MinIO Client (mc) and MinIO KES projects are archived and no longer maintained.

So the CI step that installed `mc` could not work either. It was also failing badly rather than loudly: `curl -sL` without `-f` writes the 410 body to `/tmp/mc`, and the step then chmods and executes an HTML page. That step now runs `mc` from the quay.io image instead.

`quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z` resolves to digest `sha256:14cea493d9a34af32...`, the same image the Hub served before removal. So this changes where we pull from, not what we run.

Tags are dated releases rather than `latest`, so a later rebuild cannot change the image underneath us.

## Production risk

None. Every reference changed is a local compose file or CI service container. No shipped image or runtime path pulls MinIO.

## Start here

1. `tests/integration/docker-compose.yml` and `docker-compose.yaml` — the two that gate CI.
2. `.github/workflows/ci.yml` — already pointed at quay.io but on `latest`; now pinned.

Skip `k8s/local-config-store.compose.yaml`, which is the same substitution.

## Test plan

Run locally against the real images:

- The `ci.yml` sequence verbatim: MinIO healthy in 2s, bucket created, rerun is idempotent via `--ignore-existing`, bucket confirmed present
- `docker compose -f tests/integration/docker-compose.yml up minio minio-init`: bucket, policy `trino-ducklake-read`, user `trino-reader` and its attachment all succeed, exit code 0
- CI on this PR exercises the same images through `controlplane-tests` and `integration-tests`

## Note on overlap

[#1174](https://github.com/PostHog/duckgres/pull/1174) carries the same registry move bundled with its perf-test work, using the same two tags. This PR is the standalone repair so CI can go green without waiting on that one. #1174 should rebase cleanly, or drop its copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCY5Jf2BQPCVKJTZU1TpEe
