### PR TITLE
fix: gate Trino readiness on workers and preserve missing bundle errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ This name does not change its stored org assignments or catalog-store key.
 `DUCKGRES_TRINO_CELL_ID` remains the ownership setting, with the existing default
 `cell-001`; do not change it to `legacy` to match the API display name.
 Connection details remain readiness-gated and use the existing endpoint.
+Trino readiness requires a reconciled catalog and the current tenant password
+file on every active coordinator and worker of every running backend. Secret
+projection lag remains `provisioning`; catalog creation alone does not make a
+tenant ready. Checks use namespace-scoped pod read/exec access, with batches of
+128 files, up to four concurrent observations and a five-second timeout per
+observation within the existing 30-second backend budget. These limits are
+fixed defaults. See the [readiness runbook](docs/runbooks/trino-readiness.md)
+for deployment requirements, local verification, and recovery.
 See the [Trino admin API documentation](controlplane/admin/README.md#trino-cell-views-trinogo--trino_clientgo)
 for local verification, compatibility details, and recovery instructions.
 

--- a/controlplane/admin/embed_ui.go
+++ b/controlplane/admin/embed_ui.go
@@ -32,8 +32,8 @@ const uiNotBuiltPage = `<!doctype html><html lang="en"><head><meta charset="utf-
 	`(controlplane/admin/ui), or use the Docker image which builds it.</p></body></html>`
 
 // RegisterUI serves the embedded SPA on the engine: real files (index.html,
-// /assets/*) are served directly; any other non-API GET falls back to
-// index.html so client-side routing works. The bundle carries no secrets, so it
+// /assets/*) are served directly; paths outside /api and /bundles fall back to
+// index.html so client-side routing works. The UI bundle carries no secrets, so it
 // is served unauthenticated — every data call under /api/v1 is auth-gated.
 // When no real build is embedded (only .gitkeep), a graceful "not built" notice
 // is served so the control plane still starts.
@@ -50,8 +50,9 @@ func RegisterUI(engine *gin.Engine) error {
 
 	engine.NoRoute(func(c *gin.Context) {
 		p := c.Request.URL.Path
-		// Never SPA-fallback an API path — return a JSON 404 instead of HTML.
-		if p == "/api" || strings.HasPrefix(p, "/api/") {
+		// Unregistered API and OPA bundle routes must remain absent. In
+		// particular, registry-only mode intentionally omits the legacy bundle.
+		if p == "/api" || strings.HasPrefix(p, "/api/") || p == "/bundles" || strings.HasPrefix(p, "/bundles/") {
 			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 			return
 		}

--- a/controlplane/admin/embed_ui_test.go
+++ b/controlplane/admin/embed_ui_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/posthog/duckgres/controlplane/provisioner/opa"
 )
 
 func TestRegisterUIServesSPA(t *testing.T) {
@@ -45,6 +46,49 @@ func TestRegisterUIServesSPA(t *testing.T) {
 			}
 			if tc.wantCType != "" && !strings.Contains(rec.Header().Get("Content-Type"), tc.wantCType) {
 				t.Fatalf("content-type = %q, want %q", rec.Header().Get("Content-Type"), tc.wantCType)
+			}
+		})
+	}
+}
+
+func TestRegisterUIPreservesBundleRouting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	store := &opa.BundleStore{}
+	store.Set(opa.NewBundle([]byte("registered-bundle")))
+	// Registry-only startup registers only cell-specific bundle routes. Use
+	// the real authenticated handler alongside the same UI fallback as the server.
+	engine.Any("/bundles/trino/cell-test", gin.WrapH(opa.NewHandler(store, opa.BearerTokenAuth("fixture-token"))))
+	if err := RegisterUI(engine); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name, method, path, token, contentType string
+		status                                 int
+	}{
+		{"missing legacy bundle", http.MethodGet, "/bundles/trino", "", "application/json", http.StatusNotFound},
+		{"missing authenticated legacy bundle", http.MethodGet, "/bundles/trino", "fixture-token", "application/json", http.StatusNotFound},
+		{"missing registered cell", http.MethodGet, "/bundles/trino/missing-cell", "fixture-token", "application/json", http.StatusNotFound},
+		{"bundle namespace root", http.MethodGet, "/bundles", "", "application/json", http.StatusNotFound},
+		{"bundle namespace slash", http.MethodGet, "/bundles/", "", "application/json", http.StatusNotFound},
+		{"missing bundle rejects POST fallback", http.MethodPost, "/bundles/trino", "", "application/json", http.StatusNotFound},
+		{"registered bundle authentication remains enforced", http.MethodGet, "/bundles/trino/cell-test", "", "text/plain", http.StatusUnauthorized},
+		{"registered bundle remains served", http.MethodGet, "/bundles/trino/cell-test", "fixture-token", "application/gzip", http.StatusOK},
+		{"client route remains served", http.MethodGet, "/orgs/example", "", "text/html", http.StatusOK},
+		{"similarly named client route remains served", http.MethodGet, "/bundles-overview", "", "text/html", http.StatusOK},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(test.method, test.path, nil)
+			if test.token != "" {
+				request.Header.Set("Authorization", "Bearer "+test.token)
+			}
+			response := httptest.NewRecorder()
+			engine.ServeHTTP(response, request)
+			if response.Code != test.status || !strings.HasPrefix(response.Header().Get("Content-Type"), test.contentType) {
+				t.Fatalf("response = %d %q, want %d %q", response.Code, response.Header().Get("Content-Type"), test.status, test.contentType)
+			}
+			if test.contentType == "application/gzip" && response.Body.String() != "registered-bundle" {
+				t.Fatalf("registered bundle response was replaced: %q", response.Body.String())
 			}
 		})
 	}

--- a/controlplane/provisioner/opa/policy.rego
+++ b/controlplane/provisioner/opa/policy.rego
@@ -721,6 +721,21 @@ allow if {
 	observer_nodes_table(input.action.resource.table)
 }
 
+# The provisioner needs the same precise node inventory to acknowledge tenant
+# password projection on every active worker before publishing tenant readiness.
+# Catalog access alone grants no other system table, browsing or mutation rights.
+allow if {
+	is_admin
+	input.action.operation == "AccessCatalog"
+	input.action.resource.catalog.name == "system"
+}
+
+allow if {
+	is_admin
+	input.action.operation == "SelectFromColumns"
+	observer_nodes_table(input.action.resource.table)
+}
+
 # ---------------------------------------------------------------------------
 # Hard denies for customer principals.
 #

--- a/controlplane/provisioner/opa/policy_test.go
+++ b/controlplane/provisioner/opa/policy_test.go
@@ -1791,13 +1791,11 @@ func TestObserverSystemGrantIsPinnedToTheNodesTable(t *testing.T) {
 	}
 }
 
-// The grant is keyed on is_observer, so it must not leak to a tenant or to
-// the admin principal -- neither of which has any business reading it, and
-// a tenant reaching the system catalog at all would be a boundary failure.
-func TestSystemNodesGrantIsObserverOnly(t *testing.T) {
+// Operational node inventory grants must not leak to tenant identities.
+func TestSystemNodesGrantExcludesTenants(t *testing.T) {
 	q := preparedPolicy(t, twoOrgFixture())
 
-	for _, user := range []string{"42", AdminPrincipal} {
+	for _, user := range []string{"42", "43"} {
 		t.Run(user, func(t *testing.T) {
 			if evalAllow(t, q, buildInput(user, "AccessCatalog", catalogResource("system"))) {
 				t.Errorf("%s must not reach the system catalog", user)
@@ -1816,5 +1814,47 @@ func TestSystemNodesGrantIsObserverOnly(t *testing.T) {
 		[]interface{}{ObserverGroup}
 	if evalAllow(t, q, in) {
 		t.Error("claiming the observer group without the observer username must grant nothing")
+	}
+}
+
+func TestTrinoProvisionerReadsOnlySystemRuntimeNodes(t *testing.T) {
+	q := preparedPolicy(t, twoOrgFixture())
+	if !evalAllow(t, q, buildInput(AdminPrincipal, "AccessCatalog", catalogResource("system"))) {
+		t.Error("provisioner must reach system for worker readiness inventory")
+	}
+	if !evalAllow(t, q, buildInput(AdminPrincipal, "SelectFromColumns", tableResource("system", "runtime", "nodes"))) {
+		t.Error("provisioner must read system.runtime.nodes for worker readiness inventory")
+	}
+	for _, table := range []struct{ catalog, schema, name string }{
+		{"system", "runtime", "queries"},
+		{"system", "runtime", "tasks"},
+		{"system", "runtime", "transactions"},
+		{"system", "metadata", "catalogs"},
+		{"system", "jdbc", "tables"},
+		{"system", "information_schema", "tables"},
+		{"system", "other", "nodes"},
+		{"other", "runtime", "nodes"},
+	} {
+		if evalAllow(t, q, buildInput(AdminPrincipal, "SelectFromColumns", tableResource(table.catalog, table.schema, table.name))) {
+			t.Errorf("provisioner node inventory grant must not read %s.%s.%s", table.catalog, table.schema, table.name)
+		}
+	}
+	for _, operation := range []string{"InsertIntoTable", "DeleteFromTable", "DropTable", "ShowTables", "FilterTables", "ShowColumns", "FilterColumns"} {
+		if evalAllow(t, q, buildInput(AdminPrincipal, operation, tableResource("system", "runtime", "nodes"))) {
+			t.Errorf("node inventory grant must not allow %s", operation)
+		}
+	}
+	for _, identity := range []struct {
+		user   string
+		groups []string
+	}{
+		{AdminPrincipal, nil},
+		{AdminPrincipal, []string{ObserverGroup}},
+		{"42", []string{AdminGroup}},
+	} {
+		if evalAllow(t, q, buildInputWithGroups(identity.user, identity.groups, "AccessCatalog", catalogResource("system"))) ||
+			evalAllow(t, q, buildInputWithGroups(identity.user, identity.groups, "SelectFromColumns", tableResource("system", "runtime", "nodes"))) {
+			t.Errorf("incomplete provisioner identity must not receive node inventory access: %s", identity.user)
+		}
 	}
 }

--- a/controlplane/provisioner/trino_nodes.go
+++ b/controlplane/provisioner/trino_nodes.go
@@ -1,0 +1,60 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// TrinoNode identifies a node as reported by its coordinator. Readiness uses
+// this inventory rather than inferring Trino membership from Kubernetes pods.
+type TrinoNode struct {
+	ID          string
+	URI         string
+	Coordinator bool
+	State       string
+}
+
+// ListNodes reads the complete coordinator inventory. Invalid rows fail the
+// whole read: silently omitting a worker could falsely acknowledge readiness.
+func (c *trinoCatalogHTTPClient) ListNodes(ctx context.Context) ([]TrinoNode, error) {
+	rows, err := c.runStatement(ctx, "SELECT node_id, http_uri, coordinator, state FROM system.runtime.nodes")
+	if err != nil {
+		return nil, fmt.Errorf("query Trino node inventory: %w", err)
+	}
+	nodes := make([]TrinoNode, 0, len(rows))
+	ids := make(map[string]bool, len(rows))
+	uris := make(map[string]bool, len(rows))
+	for i, row := range rows {
+		if len(row) != 4 {
+			return nil, fmt.Errorf("trino node inventory row %d: expected 4 columns", i)
+		}
+		id, idOK := row[0].(string)
+		uri, uriOK := row[1].(string)
+		coordinator, coordinatorOK := row[2].(bool)
+		state, stateOK := row[3].(string)
+		if !idOK || strings.TrimSpace(id) == "" || !uriOK || !coordinatorOK || !stateOK {
+			return nil, fmt.Errorf("trino node inventory row %d: invalid identity, URI, coordinator flag or state", i)
+		}
+		parsed, err := url.Parse(uri)
+		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+			return nil, fmt.Errorf("trino node inventory row %d: invalid HTTP endpoint", i)
+		}
+		// NodeSystemTable serializes NodeState using lowercase names.
+		switch state {
+		case "active", "inactive", "draining", "drained", "shutting_down":
+		default:
+			return nil, fmt.Errorf("trino node inventory row %d: unrecognized lifecycle state", i)
+		}
+		if ids[id] || uris[uri] {
+			return nil, fmt.Errorf("trino node inventory row %d: duplicate node identity or endpoint", i)
+		}
+		ids[id] = true
+		uris[uri] = true
+		nodes = append(nodes, TrinoNode{ID: id, URI: uri, Coordinator: coordinator, State: state})
+	}
+	return nodes, nil
+}

--- a/controlplane/provisioner/trino_nodes_test.go
+++ b/controlplane/provisioner/trino_nodes_test.go
@@ -1,0 +1,128 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/posthog/duckgres/controlplane/provisioner/opa"
+)
+
+func TestTrinoListNodesReadsAllPages(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, password, ok := r.BasicAuth()
+		if !ok || user != opa.AdminPrincipal || password != "test-password" || r.Header.Get("X-Trino-Source") != TrinoProvisionerSource {
+			t.Error("node inventory request did not retain provisioner authentication and source")
+		}
+		if r.Method == http.MethodPost {
+			body, _ := io.ReadAll(r.Body)
+			if string(body) != "SELECT node_id, http_uri, coordinator, state FROM system.runtime.nodes" {
+				t.Errorf("unexpected inventory SQL: %s", body)
+			}
+			_, _ = fmt.Fprintf(w, `{"data":[["coordinator","https://192.0.2.1:8443",true,"active"]],"nextUri":%q}`, server.URL+"/next")
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"data":[["worker","http://192.0.2.2:8080",false,"active"]]}`)
+	}))
+	defer server.Close()
+	client := NewTrinoCatalogHTTPClient(server.URL, opa.AdminPrincipal, "test-password", "").(*trinoCatalogHTTPClient)
+	nodes, err := client.ListNodes(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []TrinoNode{
+		{ID: "coordinator", URI: "https://192.0.2.1:8443", Coordinator: true, State: "active"},
+		{ID: "worker", URI: "http://192.0.2.2:8080", State: "active"},
+	}
+	if !reflect.DeepEqual(nodes, want) {
+		t.Fatalf("nodes = %+v, want %+v", nodes, want)
+	}
+}
+
+func TestTrinoListNodesRejectsIncompleteInventory(t *testing.T) {
+	valid := []any{"worker", "http://192.0.2.2:8080", false, "active"}
+	tests := []struct {
+		name string
+		row  []any
+	}{
+		{"short row", []any{"other", "http://192.0.2.3:8080", false}},
+		{"extra column", []any{"other", "http://192.0.2.3:8080", false, "active", "extra"}},
+		{"null ID", []any{nil, "http://192.0.2.3:8080", false, "active"}},
+		{"blank ID", []any{" ", "http://192.0.2.3:8080", false, "active"}},
+		{"nonstring URI", []any{"other", 123, false, "active"}},
+		{"relative URI", []any{"other", "/worker", false, "active"}},
+		{"unsupported URI", []any{"other", "file:///worker", false, "active"}},
+		{"missing host", []any{"other", "http://:8080", false, "active"}},
+		{"invalid port", []any{"other", "http://192.0.2.3:wrong", false, "active"}},
+		{"URI credentials", []any{"other", "http://user:password@192.0.2.3:8080", false, "active"}},
+		{"URI query", []any{"other", "http://192.0.2.3:8080?x=y", false, "active"}},
+		{"URI fragment", []any{"other", "http://192.0.2.3:8080#fragment", false, "active"}},
+		{"null coordinator", []any{"other", "http://192.0.2.3:8080", nil, "active"}},
+		{"string coordinator", []any{"other", "http://192.0.2.3:8080", "false", "active"}},
+		{"null state", []any{"other", "http://192.0.2.3:8080", false, nil}},
+		{"unknown state", []any{"other", "http://192.0.2.3:8080", false, "UNKNOWN"}},
+		{"duplicate ID", []any{"worker", "http://192.0.2.3:8080", false, "active"}},
+		{"duplicate URI", []any{"other", "http://192.0.2.2:8080", false, "active"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{"data": [][]any{valid, test.row}})
+			}))
+			defer server.Close()
+			client := NewTrinoCatalogHTTPClient(server.URL, "", "", "").(*trinoCatalogHTTPClient)
+			nodes, err := client.ListNodes(context.Background())
+			if err == nil || nodes != nil {
+				t.Fatalf("invalid inventory must fail without partial results: nodes=%+v err=%v", nodes, err)
+			}
+		})
+	}
+}
+
+func TestTrinoListNodesPreservesEmptyAndInactiveInventory(t *testing.T) {
+	for _, state := range []string{"", "inactive", "draining", "drained", "shutting_down"} {
+		t.Run(state, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if state == "" {
+					_, _ = fmt.Fprint(w, `{"data":[]}`)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"data": [][]any{{"worker", "http://[2001:db8::1]:8080", false, state}}})
+			}))
+			defer server.Close()
+			client := NewTrinoCatalogHTTPClient(server.URL, "", "", "").(*trinoCatalogHTTPClient)
+			nodes, err := client.ListNodes(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if state == "" {
+				if len(nodes) != 0 {
+					t.Fatalf("empty inventory returned %+v", nodes)
+				}
+			} else if len(nodes) != 1 || nodes[0].State != state {
+				t.Fatalf("inactive inventory was discarded: %+v", nodes)
+			}
+		})
+	}
+}
+
+func TestTrinoListNodesPropagatesQueryFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{"error":{"errorName":"PERMISSION_DENIED","errorType":"USER_ERROR","message":"node inventory denied"}}`)
+	}))
+	defer server.Close()
+	client := NewTrinoCatalogHTTPClient(server.URL, "", "", "").(*trinoCatalogHTTPClient)
+	nodes, err := client.ListNodes(context.Background())
+	if nodes != nil || err == nil || !strings.Contains(err.Error(), "PERMISSION_DENIED") {
+		t.Fatalf("query failure was not preserved: nodes=%+v err=%v", nodes, err)
+	}
+}

--- a/controlplane/provisioner/trino_provisioner.go
+++ b/controlplane/provisioner/trino_provisioner.go
@@ -145,9 +145,8 @@ const (
 const TrinoTenantSecretName = "trino-tenant-secrets" //nolint:gosec // K8s object name, not a credential
 
 // DefaultTrinoTenantSecretMountPath is where the chart mounts
-// TrinoTenantSecretName inside the Trino pods. The provisioner never reads
-// this path itself — it only renders it into each catalog's
-// `ducklake.metadata.connection-password-file` — so it MUST agree with the
+// TrinoTenantSecretName inside the Trino pods. Catalog properties and mounted
+// credential readiness checks use this path, so it MUST agree with the
 // chart's volumeMount. Override with DUCKGRES_TRINO_TENANT_SECRET_MOUNT_PATH
 // if the chart mounts it elsewhere.
 const DefaultTrinoTenantSecretMountPath = "/etc/trino/tenant-secrets"
@@ -221,6 +220,7 @@ func TrinoResourceGroupName(principal string) string {
 // is exported so tests can inject a fake at the function boundary.
 type TrinoCatalogClient interface {
 	ListCatalogs(ctx context.Context) ([]string, error)
+	ListNodes(ctx context.Context) ([]TrinoNode, error)
 	CreateCatalog(ctx context.Context, name string, props map[string]string) error
 	AlterCatalog(ctx context.Context, name string, props map[string]string) error
 	DropCatalog(ctx context.Context, name string) error
@@ -263,6 +263,10 @@ type TrinoProvisionerOpts struct {
 	// Kubernetes is used for the auth Secret, tenant-password Secret and
 	// resource-groups ConfigMap projections in the Trino namespace.
 	Kubernetes kubernetes.Interface
+
+	// SecretReadiness confirms the tenant credentials visible on serving Trino
+	// nodes. Nil uses Kubernetes pod exec with in-cluster credentials.
+	SecretReadiness TrinoSecretReadiness
 
 	// Namespace overrides TrinoCustomerNamespace. Empty == default.
 	// Useful for dev clusters that namespace Trino differently.
@@ -396,6 +400,7 @@ type TrinoProvisioner struct {
 	warehouses              TrinoWarehouseStore
 	ducklings               TrinoDucklingResolver
 	kubernetes              kubernetes.Interface
+	secretReadiness         TrinoSecretReadiness
 	namespace               string
 	cellID                  string
 	explicitAssignmentOnly  bool
@@ -507,12 +512,17 @@ func NewTrinoProvisioner(opts TrinoProvisionerOpts) (*TrinoProvisioner, error) {
 	if maxConns <= 0 {
 		maxConns = defaultTrinoS3MaxConnections
 	}
+	secretReadiness := opts.SecretReadiness
+	if secretReadiness == nil {
+		secretReadiness = NewKubernetesTrinoSecretReadiness(opts.Kubernetes, nil)
+	}
 	return &TrinoProvisioner{
 		store:                   opts.Store,
 		bootstrapSentinel:       opts.BootstrapSentinel,
 		warehouses:              opts.Warehouses,
 		ducklings:               opts.Ducklings,
 		kubernetes:              opts.Kubernetes,
+		secretReadiness:         secretReadiness,
 		namespace:               ns,
 		cellID:                  cell,
 		explicitAssignmentOnly:  opts.ExplicitAssignmentOnly,
@@ -1264,7 +1274,7 @@ func (p *TrinoProvisioner) writePerOrgStates(
 				msg = "waiting for warehouse provisioning to complete"
 			}
 		default:
-			// Created or Existed + no global failure == Ready.
+			// Catalog reconciled, member credentials observed, no global failure.
 			nextState = configstore.ManagedWarehouseStateReady
 			msg = ""
 		}
@@ -1323,6 +1333,9 @@ type tenantSecretProjection struct {
 	// rather than re-reading it (or, worse, reading object-store fields
 	// off the config store, where they are never populated).
 	statuses map[string]*DucklingStatus
+	// data is the exact Secret payload written during this reconcile. Readiness
+	// compares mounted credentials against this generation, not a later read.
+	data map[string][]byte
 }
 
 // reconcileTenantSecrets resolves every enabled org's DuckLake
@@ -1376,6 +1389,7 @@ func (p *TrinoProvisioner) reconcileTenantSecrets(ctx context.Context, orgs []co
 	if err := p.replaceSecret(ctx, TrinoTenantSecretName, data); err != nil {
 		return tenantSecretProjection{}, err
 	}
+	proj.data = data
 	return proj, nil
 }
 
@@ -1414,7 +1428,77 @@ func (p *TrinoProvisioner) reconcileCatalogs(
 func (p *TrinoProvisioner) reconcileBoundedBackend(ctx context.Context, orgs []configstore.TrinoEnabledOrg, tenants tenantSecretProjection, catalog TrinoCatalogClient) (map[string]catalogOutcome, error) {
 	backendCtx, cancel := context.WithTimeout(ctx, p.catalogTimeout)
 	defer cancel()
-	return p.reconcileBackendCatalogs(backendCtx, orgs, tenants, catalog)
+	outcomes, catalogErr := p.reconcileBackendCatalogs(backendCtx, orgs, tenants, catalog)
+	expected := make(map[string][]byte)
+	for org, outcome := range outcomes {
+		if outcome.Err == nil && !outcome.Pending && (outcome.Created || outcome.Existed) {
+			expected[org] = tenants.data[org]
+		}
+	}
+	if len(expected) == 0 {
+		return outcomes, catalogErr
+	}
+
+	pending, readinessErr := p.reconcileBackendReadiness(backendCtx, catalog, expected)
+	for org := range expected {
+		if readinessErr != nil {
+			outcomes[org] = catalogOutcome{Err: readinessErr}
+		} else if reason, waiting := pending[org]; waiting {
+			outcomes[org] = catalogOutcome{Pending: true, PendingReason: reason}
+		}
+	}
+	return outcomes, errors.Join(catalogErr, readinessErr)
+}
+
+// A successful CREATE CATALOG only validates the coordinator's local files.
+// Observe the same credentials on every active member before declaring this
+// backend ready, including when the catalog already existed on this tick.
+func (p *TrinoProvisioner) reconcileBackendReadiness(ctx context.Context, catalog TrinoCatalogClient, expected map[string][]byte) (map[string]string, error) {
+	nodes, err := catalog.ListNodes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read Trino readiness membership: %w", err)
+	}
+	active := activeTrinoMembers(nodes)
+	coordinator, worker := false, false
+	for _, node := range active {
+		coordinator = coordinator || node.Coordinator
+		worker = worker || !node.Coordinator
+	}
+	if !coordinator || !worker {
+		return trinoAllPending(expected, "waiting for an active Trino coordinator and worker"), nil
+	}
+	pending, err := p.secretReadiness.Check(ctx, p.namespace, p.tenantSecretMountPath, expected, active)
+	if err != nil {
+		return nil, fmt.Errorf("verify Trino mounted credentials: %w", err)
+	}
+	after, err := catalog.ListNodes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("verify Trino readiness membership: %w", err)
+	}
+	current := activeTrinoMembers(after)
+	if len(active) != len(current) {
+		return trinoAllPending(expected, "Trino membership changed during credential observation"), nil
+	}
+	for i := range active {
+		if active[i] != current[i] {
+			return trinoAllPending(expected, "Trino membership changed during credential observation"), nil
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return pending, nil
+}
+
+func activeTrinoMembers(nodes []TrinoNode) []TrinoNode {
+	active := make([]TrinoNode, 0, len(nodes))
+	for _, node := range nodes {
+		if strings.EqualFold(node.State, "active") {
+			active = append(active, node)
+		}
+	}
+	sort.Slice(active, func(i, j int) bool { return active[i].ID < active[j].ID })
+	return active
 }
 
 func (p *TrinoProvisioner) reconcileBackendCatalogs(

--- a/controlplane/provisioner/trino_provisioner_test.go
+++ b/controlplane/provisioner/trino_provisioner_test.go
@@ -138,6 +138,18 @@ type fakeCatalogClient struct {
 	dropped   []string
 	listErr   error
 	createErr error
+	nodes     []TrinoNode
+	nodesErr  error
+}
+
+func (c *fakeCatalogClient) ListNodes(context.Context) ([]TrinoNode, error) {
+	if c.nodesErr != nil {
+		return nil, c.nodesErr
+	}
+	if c.nodes != nil {
+		return append([]TrinoNode{}, c.nodes...), nil
+	}
+	return readyTrinoNodes(), nil
 }
 
 func (c *fakeCatalogClient) ListCatalogs(ctx context.Context) ([]string, error) {
@@ -786,13 +798,14 @@ func newTestTrinoProvisioner(t *testing.T, orgs []configstore.TrinoEnabledOrg, w
 			}
 			return h.ducklings[orgID], nil
 		},
-		Kubernetes:    h.kube,
-		Namespace:     TrinoCustomerNamespace,
-		CellID:        testCellID,
-		Catalog:       h.catalog,
-		BundleStore:   h.bundles,
-		BundleBuilder: h.builder,
-		AWSRegion:     "us-east-1",
+		Kubernetes:      h.kube,
+		SecretReadiness: &fakeTrinoSecretReadiness{},
+		Namespace:       TrinoCustomerNamespace,
+		CellID:          testCellID,
+		Catalog:         h.catalog,
+		BundleStore:     h.bundles,
+		BundleBuilder:   h.builder,
+		AWSRegion:       "us-east-1",
 	})
 	if err != nil {
 		t.Fatalf("NewTrinoProvisioner: %v", err)

--- a/controlplane/provisioner/trino_readiness_test.go
+++ b/controlplane/provisioner/trino_readiness_test.go
@@ -1,0 +1,274 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/controlplane/configstore"
+)
+
+type fakeTrinoSecretReadiness struct {
+	check func(context.Context, string, string, map[string][]byte, []TrinoNode) (map[string]string, error)
+	calls int
+}
+
+func (f *fakeTrinoSecretReadiness) Check(ctx context.Context, namespace, path string, expected map[string][]byte, nodes []TrinoNode) (map[string]string, error) {
+	f.calls++
+	if f.check != nil {
+		return f.check(ctx, namespace, path, expected, nodes)
+	}
+	return nil, nil
+}
+
+func readyTrinoNodes() []TrinoNode {
+	return []TrinoNode{
+		{ID: "coordinator", URI: "http://192.0.2.10:8080", Coordinator: true, State: "active"},
+		{ID: "worker", URI: "http://192.0.2.11:8080", State: "active"},
+	}
+}
+
+func trinoReadinessHarness(t *testing.T) *testProvisionerHarness {
+	t.Helper()
+	return newTestTrinoProvisioner(t, []configstore.TrinoEnabledOrg{
+		{OrgID: "tenant-a", DatabaseName: "tenant-a", CellID: testCellID, RootPasswordHash: "hash-a"},
+		{OrgID: "tenant-b", DatabaseName: "tenant-b", CellID: testCellID, RootPasswordHash: "hash-b"},
+	}, map[string]*configstore.ManagedWarehouse{"tenant-a": readyWarehouse("tenant-a"), "tenant-b": readyWarehouse("tenant-b")})
+}
+
+func assertTrinoReadinessState(t *testing.T, h *testProvisionerHarness, org string, want configstore.ManagedWarehouseProvisioningState) configstore.TrinoStateUpdate {
+	t.Helper()
+	state, ok := h.store.lastState(org)
+	if !ok || state.State != want {
+		t.Fatalf("%s: got %+v, want %s", org, state, want)
+	}
+	return state
+}
+
+func TestTrinoReadinessWaitsForWorkerProjectionAfterCatalogCreation(t *testing.T) {
+	h := trinoReadinessHarness(t)
+	lagging := true
+	checker := &fakeTrinoSecretReadiness{check: func(_ context.Context, namespace, path string, expected map[string][]byte, nodes []TrinoNode) (map[string]string, error) {
+		if namespace != TrinoCustomerNamespace || path != DefaultTrinoTenantSecretMountPath || len(nodes) != 2 {
+			t.Fatal("readiness did not check the serving nodes in this cell")
+		}
+		if string(expected["tenant-b"]) != h.ducklings["tenant-b"].MetadataStore.Password {
+			t.Fatal("readiness did not receive the password projected in this reconcile")
+		}
+		if lagging {
+			return map[string]string{"tenant-b": "waiting for tenant password projection on worker"}, nil
+		}
+		return nil, nil
+	}}
+	h.provisioner.secretReadiness = checker
+	if err := h.provisioner.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.catalog.created) != 2 {
+		t.Fatal("coordinator catalog creation did not succeed in the reproduction")
+	}
+	assertTrinoReadinessState(t, h, "tenant-a", configstore.ManagedWarehouseStateReady)
+	state := assertTrinoReadinessState(t, h, "tenant-b", configstore.ManagedWarehouseStateProvisioning)
+	if state.ReadyAt != nil || state.FailedAt != nil || !strings.Contains(state.StatusMessage, "password projection") {
+		t.Fatalf("ordinary projection lag must remain pending: %+v", state)
+	}
+	lagging = false
+	if err := h.provisioner.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	assertTrinoReadinessState(t, h, "tenant-b", configstore.ManagedWarehouseStateReady)
+	if checker.calls != 2 {
+		t.Fatal("an existing coordinator catalog bypassed worker readiness")
+	}
+}
+
+func TestTrinoReadinessIncludesEveryRunningBackend(t *testing.T) {
+	h := trinoReadinessHarness(t)
+	greenNodes := readyTrinoNodes()
+	greenNodes[1].ID = "green-worker"
+	greenNodes[1].URI = "http://192.0.2.21:8080"
+	h.provisioner.additionalCatalogs = []TrinoCatalogClient{&fakeCatalogClient{nodes: greenNodes}}
+	checker := &fakeTrinoSecretReadiness{check: func(_ context.Context, _, _ string, _ map[string][]byte, nodes []TrinoNode) (map[string]string, error) {
+		for _, node := range nodes {
+			if node.ID == "green-worker" {
+				return map[string]string{"tenant-b": "waiting for green worker projection"}, nil
+			}
+		}
+		return nil, nil
+	}}
+	h.provisioner.secretReadiness = checker
+	if err := h.provisioner.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	assertTrinoReadinessState(t, h, "tenant-a", configstore.ManagedWarehouseStateReady)
+	assertTrinoReadinessState(t, h, "tenant-b", configstore.ManagedWarehouseStateProvisioning)
+	if checker.calls != 2 {
+		t.Fatal("not every running backend was checked")
+	}
+}
+
+func TestTrinoReadinessRequiresActiveCoordinatorAndWorker(t *testing.T) {
+	for _, nodes := range [][]TrinoNode{nil, readyTrinoNodes()[:1], readyTrinoNodes()[1:]} {
+		h := trinoReadinessHarness(t)
+		h.catalog.nodes = append([]TrinoNode{}, nodes...)
+		checker := &fakeTrinoSecretReadiness{}
+		h.provisioner.secretReadiness = checker
+		if err := h.provisioner.Reconcile(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		assertTrinoReadinessState(t, h, "tenant-a", configstore.ManagedWarehouseStateProvisioning)
+		if checker.calls != 0 {
+			t.Fatal("incomplete topology must not produce a projection acknowledgment")
+		}
+	}
+}
+
+func TestTrinoReadinessRechecksMembershipAndExistingReadyTenants(t *testing.T) {
+	h := trinoReadinessHarness(t)
+	checker := &fakeTrinoSecretReadiness{}
+	h.provisioner.secretReadiness = checker
+	if err := h.provisioner.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	assertTrinoReadinessState(t, h, "tenant-a", configstore.ManagedWarehouseStateReady)
+	checker.check = func(_ context.Context, _, _ string, _ map[string][]byte, _ []TrinoNode) (map[string]string, error) {
+		h.catalog.nodes = append(readyTrinoNodes(), TrinoNode{ID: "new-worker", URI: "http://192.0.2.12:8080", State: "active"})
+		return nil, nil
+	}
+	if err := h.provisioner.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	assertTrinoReadinessState(t, h, "tenant-a", configstore.ManagedWarehouseStateProvisioning)
+	checker.check = nil
+	if err := h.provisioner.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	assertTrinoReadinessState(t, h, "tenant-a", configstore.ManagedWarehouseStateReady)
+}
+
+func TestTrinoReadinessDistinguishesReplacementFromInventoryReordering(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		after   []TrinoNode
+		want    configstore.ManagedWarehouseProvisioningState
+		message string
+	}{
+		{
+			name: "same length replacement",
+			after: []TrinoNode{
+				readyTrinoNodes()[0],
+				{ID: "replacement-worker", URI: "http://192.0.2.12:8080", State: "active"},
+			},
+			want:    configstore.ManagedWarehouseStateProvisioning,
+			message: "membership changed",
+		},
+		{
+			name:  "same members in different order",
+			after: []TrinoNode{readyTrinoNodes()[1], readyTrinoNodes()[0]},
+			want:  configstore.ManagedWarehouseStateReady,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := trinoReadinessHarness(t)
+			h.catalog.nodes = readyTrinoNodes()
+			h.provisioner.secretReadiness = &fakeTrinoSecretReadiness{check: func(_ context.Context, _, _ string, _ map[string][]byte, _ []TrinoNode) (map[string]string, error) {
+				h.catalog.nodes = test.after
+				return nil, nil
+			}}
+			if err := h.provisioner.Reconcile(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			for _, org := range []string{"tenant-a", "tenant-b"} {
+				state := assertTrinoReadinessState(t, h, org, test.want)
+				if !strings.Contains(state.StatusMessage, test.message) {
+					t.Fatalf("membership transition lost its reason: %+v", state)
+				}
+			}
+		})
+	}
+}
+
+func TestTrinoReadinessAcknowledgmentPreservesCatalogFailureAndPending(t *testing.T) {
+	failure := errors.New("catalog configuration rejected")
+	for _, test := range []struct {
+		name       string
+		catalogErr error
+		want       configstore.ManagedWarehouseProvisioningState
+		message    string
+	}{
+		{"failed catalog", failure, configstore.ManagedWarehouseStateFailed, failure.Error()},
+		{"pending coordinator projection", trinoSecretMountLagError("tenant-b"), configstore.ManagedWarehouseStateProvisioning, "waiting for the tenant password file"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h := trinoReadinessHarness(t)
+			// One existing catalog can pass worker observation while the other
+			// tenant's catalog creation is still pending or has failed.
+			h.catalog.existing = []string{TrinoCatalogName("tenant-a")}
+			h.catalog.createErr = test.catalogErr
+			checker := &fakeTrinoSecretReadiness{check: func(_ context.Context, _, _ string, expected map[string][]byte, _ []TrinoNode) (map[string]string, error) {
+				if len(expected) != 1 || len(expected["tenant-a"]) == 0 {
+					t.Fatalf("unfinished catalog must not be included in a successful readiness acknowledgment: %v", len(expected))
+				}
+				return nil, nil
+			}}
+			h.provisioner.secretReadiness = checker
+			err := h.provisioner.Reconcile(context.Background())
+			if test.want == configstore.ManagedWarehouseStateFailed {
+				if !errors.Is(err, failure) {
+					t.Fatalf("catalog failure was lost: %v", err)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if checker.calls != 1 {
+				t.Fatal("test did not observe successful worker readiness for the existing catalog")
+			}
+			state := assertTrinoReadinessState(t, h, "tenant-b", test.want)
+			if !strings.Contains(state.StatusMessage, test.message) || state.ReadyAt != nil {
+				t.Fatalf("readiness acknowledgment overwrote the original catalog outcome: %+v", state)
+			}
+		})
+	}
+}
+
+func TestTrinoReadinessErrorsCannotMarkTenantReady(t *testing.T) {
+	for _, stage := range []string{"node inventory", "projection check"} {
+		t.Run(stage, func(t *testing.T) {
+			h := trinoReadinessHarness(t)
+			failure := errors.New("readiness unavailable")
+			checker := &fakeTrinoSecretReadiness{}
+			h.provisioner.secretReadiness = checker
+			if stage == "node inventory" {
+				h.catalog.nodesErr = failure
+			} else {
+				checker.check = func(context.Context, string, string, map[string][]byte, []TrinoNode) (map[string]string, error) {
+					return nil, failure
+				}
+			}
+			if err := h.provisioner.Reconcile(context.Background()); !errors.Is(err, failure) {
+				t.Fatalf("expected readiness error, got %v", err)
+			}
+			assertTrinoReadinessState(t, h, "tenant-a", configstore.ManagedWarehouseStateFailed)
+		})
+	}
+}
+
+func TestTrinoReadinessIsBoundedByBackendDeadline(t *testing.T) {
+	h := trinoReadinessHarness(t)
+	if _, err := h.provisioner.Bootstrap(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	h.provisioner.catalogTimeout = 10 * time.Millisecond
+	h.provisioner.secretReadiness = &fakeTrinoSecretReadiness{check: func(ctx context.Context, _, _ string, _ map[string][]byte, _ []TrinoNode) (map[string]string, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}}
+	if err := h.provisioner.Reconcile(context.Background()); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected bounded readiness failure, got %v", err)
+	}
+	assertTrinoReadinessState(t, h, "tenant-a", configstore.ManagedWarehouseStateFailed)
+}

--- a/controlplane/provisioner/trino_secret_readiness.go
+++ b/controlplane/provisioner/trino_secret_readiness.go
@@ -1,0 +1,395 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net"
+	"net/url"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// TrinoSecretReadiness observes the desired credential files on the actual
+// members of a backend. Missing map entries have been observed matching.
+type TrinoSecretReadiness interface {
+	Check(context.Context, string, string, map[string][]byte, []TrinoNode) (map[string]string, error)
+}
+
+// TrinoPodExecutor executes a read-only observation in one container. Its output
+// and errors are private: the readiness checker never returns them to callers.
+type TrinoPodExecutor interface {
+	Exec(context.Context, string, string, string, []string) ([]byte, error)
+}
+
+type kubernetesTrinoSecretReadiness struct {
+	kube     kubernetes.Interface
+	executor TrinoPodExecutor
+}
+
+// NewKubernetesTrinoSecretReadiness checks mounted files without caching their
+// contents or relying on deployment labels. A nil executor uses in-cluster exec.
+func NewKubernetesTrinoSecretReadiness(kube kubernetes.Interface, executor TrinoPodExecutor) TrinoSecretReadiness {
+	if executor == nil {
+		executor = NewTrinoPodExecutor(kube, nil)
+	}
+	return &kubernetesTrinoSecretReadiness{kube: kube, executor: executor}
+}
+
+type trinoSPDYExecutor struct {
+	kube   kubernetes.Interface
+	config *rest.Config
+}
+
+// NewTrinoPodExecutor uses the supplied Kubernetes REST configuration, or lazily
+// resolves in-cluster configuration when the first observation is requested.
+func NewTrinoPodExecutor(kube kubernetes.Interface, config *rest.Config) TrinoPodExecutor {
+	return &trinoSPDYExecutor{kube: kube, config: config}
+}
+
+func (e *trinoSPDYExecutor) Exec(ctx context.Context, namespace, pod, container string, command []string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	config := e.config
+	if config == nil {
+		var err error
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, errors.New("trino observation client configuration unavailable")
+		}
+	}
+	client := e.kube.CoreV1().RESTClient()
+	if client == nil {
+		return nil, errors.New("trino observation REST client unavailable")
+	}
+	endpoint := client.Post().Namespace(namespace).Resource("pods").Name(pod).SubResource("exec").VersionedParams(&corev1.PodExecOptions{Container: container, Command: command, Stdout: true, Stderr: true}, scheme.ParameterCodec).URL()
+	executor, err := remotecommand.NewSPDYExecutor(config, "POST", endpoint)
+	if err != nil {
+		return nil, errors.New("trino observation transport initialization failed")
+	}
+	var out trinoObservationBuffer
+	if err := executor.StreamWithContext(ctx, remotecommand.StreamOptions{Stdout: &out, Stderr: io.Discard}); err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, errors.New("trino mounted credential observation failed")
+	}
+	return out.Bytes(), nil
+}
+
+// Cap output even if the remote process behaves unexpectedly. No stderr is kept.
+type trinoObservationBuffer struct{ buffer bytes.Buffer }
+
+func (b *trinoObservationBuffer) Bytes() []byte { return b.buffer.Bytes() }
+
+func (b *trinoObservationBuffer) Write(p []byte) (int, error) {
+	if b.buffer.Len()+len(p) > 32768 {
+		return 0, errors.New("trino observation output limit exceeded")
+	}
+	return b.buffer.Write(p)
+}
+
+const trinoSecretBatchSize = 128
+
+// Paths travel as positional arguments, never shell source. Only a synthetic ID
+// and digest leave the container; sha256sum never receives a tenant filename to
+// print, and file contents are neither arguments nor output.
+const trinoSecretObservationScript = `set -f
+while [ "$#" -ge 2 ]; do
+ id=$1
+ file=$2
+ shift 2
+ if [ ! -f "$file" ] || [ ! -r "$file" ]; then
+  printf '%s MISSING\n' "$id"
+  continue
+ fi
+ digest=$(sha256sum < "$file" 2>/dev/null) || exit 1
+ digest=${digest%% *}
+ printf '%s %s\n' "$id" "$digest"
+done
+`
+
+type trinoObservedPod struct {
+	pod       corev1.Pod
+	container corev1.Container
+	status    corev1.ContainerStatus
+	port      string
+}
+
+func trinoAllPending(expected map[string][]byte, reason string) map[string]string {
+	pending := make(map[string]string, len(expected))
+	for org := range expected {
+		pending[org] = reason
+	}
+	return pending
+}
+
+func (c *kubernetesTrinoSecretReadiness) Check(ctx context.Context, namespace, mountPath string, expected map[string][]byte, nodes []TrinoNode) (map[string]string, error) {
+	if len(expected) == 0 {
+		return map[string]string{}, nil
+	}
+	if namespace == "" || !path.IsAbs(mountPath) || path.Clean(mountPath) != mountPath {
+		return nil, errors.New("invalid Trino credential observation location")
+	}
+	keys := make([]string, 0, len(expected))
+	for org := range expected {
+		if !secretDataKeyPattern.MatchString(org) || org == "." || org == ".." {
+			return nil, errors.New("invalid Trino tenant credential key")
+		}
+		keys = append(keys, org)
+	}
+	sort.Strings(keys)
+	pods, err := c.kube.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, errors.New("could not list Trino member pods for credential observation")
+	}
+	observed := make([]trinoObservedPod, 0, len(nodes))
+	seen := make(map[string]bool)
+	for _, node := range nodes {
+		if !strings.EqualFold(node.State, "active") {
+			continue
+		}
+		endpoint, err := url.Parse(node.URI)
+		if err != nil || net.ParseIP(endpoint.Hostname()) == nil {
+			return nil, errors.New("trino member URI must identify a pod IP")
+		}
+		ip := net.ParseIP(endpoint.Hostname()).String()
+		if seen[ip] {
+			return nil, errors.New("ambiguous Trino member pod mapping")
+		}
+		seen[ip] = true
+		var matching []corev1.Pod
+		for _, pod := range pods.Items {
+			if parsed := net.ParseIP(pod.Status.PodIP); parsed != nil && parsed.String() == ip {
+				matching = append(matching, pod)
+			}
+		}
+		if len(matching) > 1 {
+			return nil, errors.New("ambiguous Trino member pod mapping")
+		}
+		if len(matching) == 0 {
+			return trinoAllPending(expected, "waiting for a Trino member pod"), nil
+		}
+		pod := matching[0]
+		if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
+			return trinoAllPending(expected, "waiting for a running Trino member pod"), nil
+		}
+		container, err := trinoCredentialContainer(pod, mountPath, endpoint.Port(), keys)
+		if err != nil {
+			return nil, err
+		}
+		var status corev1.ContainerStatus
+		for _, candidate := range pod.Status.ContainerStatuses {
+			if candidate.Name == container.Name {
+				status = candidate
+			}
+		}
+		if !status.Ready || status.State.Running == nil || status.ContainerID == "" {
+			return trinoAllPending(expected, "waiting for a ready Trino member container"), nil
+		}
+		observed = append(observed, trinoObservedPod{pod: pod, container: container, status: status, port: endpoint.Port()})
+	}
+	if len(observed) == 0 {
+		return trinoAllPending(expected, "waiting for active Trino members"), nil
+	}
+	pending := make(map[string]string)
+	var firstErr error
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	slots := make(chan struct{}, 4)
+	for _, member := range observed {
+		wg.Add(1)
+		go func(member trinoObservedPod) {
+			defer wg.Done()
+			select {
+			case slots <- struct{}{}:
+				defer func() { <-slots }()
+			case <-ctx.Done():
+				mu.Lock()
+				firstErr = ctx.Err()
+				mu.Unlock()
+				return
+			}
+			result, err := c.observeMember(ctx, namespace, mountPath, keys, expected, member)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil && firstErr == nil {
+				firstErr = err
+			}
+			for org, reason := range result {
+				pending[org] = reason
+			}
+		}(member)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	after, err := c.kube.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, errors.New("could not verify Trino member pods after credential observation")
+	}
+	for _, member := range observed {
+		count := 0
+		for _, pod := range after.Items {
+			if pod.Status.PodIP != member.pod.Status.PodIP {
+				continue
+			}
+			count++
+			if !trinoSameObservedMember(member, pod, mountPath, keys) {
+				return trinoAllPending(expected, "Trino membership changed during credential observation"), nil
+			}
+		}
+		if count != 1 {
+			return trinoAllPending(expected, "Trino membership changed during credential observation"), nil
+		}
+	}
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return pending, nil
+}
+
+func trinoCredentialContainer(pod corev1.Pod, mountPath, port string, keys []string) (corev1.Container, error) {
+	var candidates []corev1.Container
+	for _, container := range pod.Spec.Containers {
+		for _, mount := range container.VolumeMounts {
+			if mount.MountPath != mountPath {
+				continue
+			}
+			if !mount.ReadOnly || mount.SubPath != "" || mount.SubPathExpr != "" {
+				return corev1.Container{}, errors.New("trino credential mount must be a read-only whole Secret volume")
+			}
+			found := false
+			for _, volume := range pod.Spec.Volumes {
+				if volume.Name != mount.Name || volume.Secret == nil || volume.Secret.SecretName != TrinoTenantSecretName {
+					continue
+				}
+				found = true
+				if len(volume.Secret.Items) > 0 {
+					for _, key := range keys {
+						mapped := false
+						for _, item := range volume.Secret.Items {
+							if item.Key == key && item.Path == key {
+								mapped = true
+							}
+						}
+						if !mapped {
+							return corev1.Container{}, errors.New("trino credential volume does not project tenant keys at the catalog paths")
+						}
+					}
+				}
+			}
+			if !found {
+				return corev1.Container{}, errors.New("trino credential mount must reference the tenant Secret")
+			}
+			candidates = append(candidates, container)
+		}
+	}
+	if len(candidates) > 1 && port != "" {
+		number, err := strconv.Atoi(port)
+		if err == nil {
+			var matching []corev1.Container
+			for _, container := range candidates {
+				for _, p := range container.Ports {
+					if int(p.ContainerPort) == number {
+						matching = append(matching, container)
+						break
+					}
+				}
+			}
+			candidates = matching
+		}
+	}
+	if len(candidates) != 1 {
+		return corev1.Container{}, errors.New("trino member must have one identifiable tenant credential container")
+	}
+	return candidates[0], nil
+}
+
+func trinoSameObservedMember(before trinoObservedPod, after corev1.Pod, mountPath string, keys []string) bool {
+	if after.Name != before.pod.Name || after.UID != before.pod.UID || after.Status.Phase != corev1.PodRunning || after.DeletionTimestamp != nil {
+		return false
+	}
+	container, err := trinoCredentialContainer(after, mountPath, before.port, keys)
+	if err != nil || container.Name != before.container.Name {
+		return false
+	}
+	for _, status := range after.Status.ContainerStatuses {
+		if status.Name == before.status.Name {
+			return status.Ready && status.State.Running != nil && status.ContainerID == before.status.ContainerID && status.RestartCount == before.status.RestartCount
+		}
+	}
+	return false
+}
+
+func (c *kubernetesTrinoSecretReadiness) observeMember(ctx context.Context, namespace, mountPath string, keys []string, expected map[string][]byte, member trinoObservedPod) (map[string]string, error) {
+	pending := make(map[string]string)
+	for start := 0; start < len(keys); start += trinoSecretBatchSize {
+		end := min(start+trinoSecretBatchSize, len(keys))
+		batch := keys[start:end]
+		command := []string{"/bin/sh", "-c", trinoSecretObservationScript, "trino-secret-observation"}
+		for i, key := range batch {
+			command = append(command, strconv.Itoa(i), path.Join(mountPath, key))
+		}
+		execCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		output, err := c.executor.Exec(execCtx, namespace, member.pod.Name, member.container.Name, command)
+		expired := execCtx.Err()
+		cancel()
+		if expired != nil {
+			return nil, expired
+		}
+		if err != nil {
+			return nil, errors.New("trino mounted credential observation failed")
+		}
+		if len(output) > 32768 {
+			return nil, errors.New("invalid Trino mounted credential observation response")
+		}
+		fields := strings.Fields(string(output))
+		if len(fields) != 2*len(batch) {
+			return nil, errors.New("invalid Trino mounted credential observation response")
+		}
+		for i, key := range batch {
+			if fields[2*i] != strconv.Itoa(i) {
+				return nil, errors.New("invalid Trino mounted credential observation response")
+			}
+			digest := fields[2*i+1]
+			if digest == "MISSING" {
+				pending[key] = "waiting for tenant credential files on Trino members"
+				continue
+			}
+			decoded, err := hex.DecodeString(digest)
+			if err != nil || len(decoded) != sha256.Size {
+				return nil, errors.New("invalid Trino mounted credential observation response")
+			}
+			wanted := sha256.Sum256(expected[key])
+			if !bytes.Equal(decoded, wanted[:]) {
+				pending[key] = "waiting for current tenant credentials on Trino members"
+			}
+		}
+	}
+	return pending, nil
+}

--- a/controlplane/provisioner/trino_secret_readiness_test.go
+++ b/controlplane/provisioner/trino_secret_readiness_test.go
@@ -1,0 +1,305 @@
+//go:build kubernetes
+
+package provisioner
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type trinoReadinessExecFunc func(context.Context, string, string, string, []string) ([]byte, error)
+
+func (f trinoReadinessExecFunc) Exec(c context.Context, n, p, k string, a []string) ([]byte, error) {
+	return f(c, n, p, k, a)
+}
+
+func trinoReadinessPod(name, ip string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "cell", UID: types.UID(name)}, Spec: corev1.PodSpec{
+		Volumes:    []corev1.Volume{{Name: "credentials", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: TrinoTenantSecretName}}}},
+		Containers: []corev1.Container{{Name: "engine", VolumeMounts: []corev1.VolumeMount{{Name: "credentials", MountPath: "/secrets", ReadOnly: true}}}},
+	}, Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: ip, ContainerStatuses: []corev1.ContainerStatus{{Name: "engine", Ready: true, ContainerID: "container://" + name, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}}}}
+}
+
+func trinoReadinessOutput(command []string, values map[string]string) []byte {
+	var b strings.Builder
+	for i := 4; i < len(command); i += 2 {
+		value, ok := values[filepath.Base(command[i+1])]
+		if !ok {
+			fmt.Fprintf(&b, "%s MISSING\n", command[i])
+			continue
+		}
+		fmt.Fprintf(&b, "%s %x\n", command[i], sha256.Sum256([]byte(value)))
+	}
+	return []byte(b.String())
+}
+
+func TestTrinoSecretReadinessWorkerLag(t *testing.T) {
+	kc := fake.NewClientset(trinoReadinessPod("coordinator", "10.0.0.1"), trinoReadinessPod("worker", "10.0.0.2"))
+	caughtUp := false
+	var calls atomic.Int32
+	executor := trinoReadinessExecFunc(func(_ context.Context, ns, pod, container string, cmd []string) ([]byte, error) {
+		calls.Add(1)
+		if ns != "cell" || container != "engine" {
+			t.Errorf("wrong exec target")
+		}
+		values := map[string]string{"tenant-a": "secret-a", "tenant-b": "secret-b"}
+		if pod == "worker" && !caughtUp {
+			values["tenant-a"] = "old"
+			delete(values, "tenant-b")
+		}
+		for _, a := range cmd {
+			if strings.Contains(a, "secret-a") || strings.Contains(a, "secret-b") {
+				t.Error("secret leaked in command")
+			}
+		}
+		return trinoReadinessOutput(cmd, values), nil
+	})
+	checker := NewKubernetesTrinoSecretReadiness(kc, executor)
+	nodes := []TrinoNode{{ID: "coordinator", URI: "http://10.0.0.1:8080", Coordinator: true, State: "active"}, {ID: "worker", URI: "http://10.0.0.2:8080", State: "active"}}
+	expected := map[string][]byte{"tenant-a": []byte("secret-a"), "tenant-b": []byte("secret-b")}
+	pending, err := checker.Check(context.Background(), "cell", "/secrets", expected, nodes)
+	if err != nil || len(pending) != 2 {
+		t.Fatalf("worker lag: pending=%v err=%v", pending, err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("want one exec per node, got %d", calls.Load())
+	}
+	caughtUp = true
+	pending, err = checker.Check(context.Background(), "cell", "/secrets", expected, nodes)
+	if err != nil || len(pending) != 0 {
+		t.Fatalf("caught up: pending=%v err=%v", pending, err)
+	}
+}
+
+func TestTrinoSecretReadinessMembershipAndMounts(t *testing.T) {
+	for _, tc := range []struct {
+		name                        string
+		mutate                      func(*corev1.Pod)
+		missing, duplicate, wantErr bool
+	}{
+		{name: "missing", missing: true}, {name: "unready", mutate: func(p *corev1.Pod) { p.Status.ContainerStatuses[0].Ready = false }},
+		{name: "terminating", mutate: func(p *corev1.Pod) { now := metav1.Now(); p.DeletionTimestamp = &now }},
+		{name: "duplicate IP", duplicate: true, wantErr: true},
+		{name: "wrong secret", mutate: func(p *corev1.Pod) { p.Spec.Volumes[0].Secret.SecretName = "other" }, wantErr: true},
+		{name: "writable", mutate: func(p *corev1.Pod) { p.Spec.Containers[0].VolumeMounts[0].ReadOnly = false }, wantErr: true},
+		{name: "subpath", mutate: func(p *corev1.Pod) { p.Spec.Containers[0].VolumeMounts[0].SubPath = "tenant" }, wantErr: true},
+		{name: "remapped key", mutate: func(p *corev1.Pod) {
+			p.Spec.Volumes[0].Secret.Items = []corev1.KeyToPath{{Key: "tenant", Path: "elsewhere"}}
+		}, wantErr: true},
+		{name: "ambiguous containers", mutate: func(p *corev1.Pod) {
+			second := p.Spec.Containers[0].DeepCopy()
+			second.Name = "sidecar"
+			p.Spec.Containers = append(p.Spec.Containers, *second)
+		}, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			kc := fake.NewClientset()
+			p := trinoReadinessPod("worker", "10.0.0.2")
+			if tc.mutate != nil {
+				tc.mutate(p)
+			}
+			if !tc.missing {
+				_, _ = kc.CoreV1().Pods("cell").Create(context.Background(), p, metav1.CreateOptions{})
+			}
+			if tc.duplicate {
+				_, _ = kc.CoreV1().Pods("cell").Create(context.Background(), trinoReadinessPod("duplicate", "10.0.0.2"), metav1.CreateOptions{})
+			}
+			checker := NewKubernetesTrinoSecretReadiness(kc, trinoReadinessExecFunc(func(context.Context, string, string, string, []string) ([]byte, error) {
+				t.Error("unexpected exec")
+				return nil, nil
+			}))
+			pending, err := checker.Check(context.Background(), "cell", "/secrets", map[string][]byte{"tenant": []byte("pw")}, []TrinoNode{{URI: "http://10.0.0.2:8080", State: "ACTIVE"}})
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v", err)
+			}
+			if !tc.wantErr && len(pending) != 1 {
+				t.Fatalf("pending=%v", pending)
+			}
+		})
+	}
+}
+
+func TestTrinoSecretReadinessReplacementAndErrors(t *testing.T) {
+	for _, mode := range []string{"replacement", "restart", "malformed", "exec error", "cancel"} {
+		t.Run(mode, func(t *testing.T) {
+			kc := fake.NewClientset(trinoReadinessPod("worker", "10.0.0.2"))
+			executor := trinoReadinessExecFunc(func(ctx context.Context, ns, pod, _ string, cmd []string) ([]byte, error) {
+				if mode == "exec error" {
+					return []byte("private stdout"), fmt.Errorf("private stderr")
+				}
+				if mode == "malformed" {
+					return []byte("private stdout"), nil
+				}
+				if mode == "cancel" {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				}
+				p, _ := kc.CoreV1().Pods(ns).Get(ctx, pod, metav1.GetOptions{})
+				if mode == "replacement" {
+					p.UID = "new"
+				} else {
+					p.Status.ContainerStatuses[0].RestartCount++
+				}
+				_, _ = kc.CoreV1().Pods(ns).Update(ctx, p, metav1.UpdateOptions{})
+				return trinoReadinessOutput(cmd, map[string]string{"tenant": "pw"}), nil
+			})
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			pending, err := NewKubernetesTrinoSecretReadiness(kc, executor).Check(ctx, "cell", "/secrets", map[string][]byte{"tenant": []byte("pw")}, []TrinoNode{{URI: "http://10.0.0.2:8080", State: "active"}})
+			if mode == "replacement" || mode == "restart" {
+				if err != nil || len(pending) != 1 {
+					t.Fatalf("pending=%v err=%v", pending, err)
+				}
+			} else if err == nil {
+				t.Fatal("expected observation error")
+			}
+			if strings.Contains(fmt.Sprint(err, pending), "private") {
+				t.Fatal("exec data leaked")
+			}
+			if mode == "cancel" && !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("deadline cause lost: %v", err)
+			}
+		})
+	}
+}
+
+func TestTrinoSecretReadinessActualShell(t *testing.T) {
+	if _, err := exec.LookPath("sha256sum"); err != nil {
+		t.Skip("sha256sum is required for production script test")
+	}
+	dir := filepath.Join(t.TempDir(), "spaces ' and ; $ literals")
+	if err := os.Mkdir(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	expected := make(map[string][]byte)
+	for i := 0; i < 260; i++ {
+		key := fmt.Sprintf("tenant-%03d", i)
+		value := []byte(fmt.Sprintf("password-%d\n", i))
+		expected[key] = value
+		if i != 17 {
+			if err := os.WriteFile(filepath.Join(dir, key), value, 0600); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	pod := trinoReadinessPod("worker", "10.0.0.2")
+	pod.Spec.Containers[0].VolumeMounts[0].MountPath = dir
+	var calls int
+	executor := trinoReadinessExecFunc(func(ctx context.Context, _, _, _ string, cmd []string) ([]byte, error) {
+		calls++
+		return exec.CommandContext(ctx, cmd[0], cmd[1:]...).Output()
+	})
+	pending, err := NewKubernetesTrinoSecretReadiness(fake.NewClientset(pod), executor).Check(context.Background(), "cell", dir, expected, []TrinoNode{{URI: "http://10.0.0.2:8080", State: "active"}})
+	if err != nil || len(pending) != 1 || pending["tenant-017"] == "" {
+		t.Fatalf("pending=%v err=%v", pending, err)
+	}
+	if calls < 2 {
+		t.Fatal("expected bounded batches")
+	}
+}
+
+func TestTrinoSecretReadinessConcurrencyAndDeadline(t *testing.T) {
+	var pods []runtime.Object
+	var nodes []TrinoNode
+	for i := 1; i <= 9; i++ {
+		ip := fmt.Sprintf("10.0.0.%d", i)
+		pods = append(pods, trinoReadinessPod(fmt.Sprintf("worker-%d", i), ip))
+		nodes = append(nodes, TrinoNode{URI: "http://" + ip + ":8080", State: "active"})
+	}
+	started := make(chan struct{}, 9)
+	release := make(chan struct{})
+	var running, maximum atomic.Int32
+	executor := trinoReadinessExecFunc(func(ctx context.Context, _, _, _ string, cmd []string) ([]byte, error) {
+		current := running.Add(1)
+		defer running.Add(-1)
+		for old := maximum.Load(); current > old; old = maximum.Load() {
+			if maximum.CompareAndSwap(old, current) {
+				break
+			}
+		}
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) > 5*time.Second {
+			t.Error("exec lacks bounded deadline")
+		}
+		started <- struct{}{}
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return trinoReadinessOutput(cmd, map[string]string{"tenant": "pw"}), nil
+	})
+	done := make(chan error, 1)
+	go func() {
+		pending, err := NewKubernetesTrinoSecretReadiness(fake.NewClientset(pods...), executor).Check(context.Background(), "cell", "/secrets", map[string][]byte{"tenant": []byte("pw")}, nodes)
+		if len(pending) != 0 && err == nil {
+			err = fmt.Errorf("unexpected pending result")
+		}
+		done <- err
+	}()
+	for i := 0; i < 4; i++ {
+		select {
+		case <-started:
+		case <-time.After(3 * time.Second):
+			close(release)
+			t.Fatal("four observations did not start")
+		}
+	}
+	select {
+	case <-started:
+		close(release)
+		t.Fatal("more than four observations started")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if maximum.Load() != 4 {
+		t.Fatalf("maximum concurrency=%d", maximum.Load())
+	}
+}
+
+func TestTrinoSecretReadinessOutputBound(t *testing.T) {
+	var buffer trinoObservationBuffer
+	if _, err := buffer.Write(make([]byte, 32768)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := buffer.Write([]byte("x")); err == nil {
+		t.Fatal("unbounded output accepted")
+	}
+}
+
+func TestTrinoSecretReadinessSelectsContainerByMemberPort(t *testing.T) {
+	pod := trinoReadinessPod("worker", "10.0.0.2")
+	pod.Spec.Containers[0].Ports = []corev1.ContainerPort{{ContainerPort: 8080}}
+	sidecar := pod.Spec.Containers[0].DeepCopy()
+	sidecar.Name = "other"
+	sidecar.Ports = []corev1.ContainerPort{{ContainerPort: 9999}}
+	pod.Spec.Containers = append(pod.Spec.Containers, *sidecar)
+	executor := trinoReadinessExecFunc(func(_ context.Context, _, _, container string, command []string) ([]byte, error) {
+		if container != "engine" {
+			t.Errorf("wrong container %q", container)
+		}
+		return trinoReadinessOutput(command, map[string]string{"tenant": "pw"}), nil
+	})
+	pending, err := NewKubernetesTrinoSecretReadiness(fake.NewClientset(pod), executor).Check(context.Background(), "cell", "/secrets", map[string][]byte{"tenant": []byte("pw")}, []TrinoNode{{URI: "http://10.0.0.2:8080", State: "active"}})
+	if err != nil || len(pending) != 0 {
+		t.Fatalf("pending=%v err=%v", pending, err)
+	}
+}

--- a/controlplane/trino_fleet_test.go
+++ b/controlplane/trino_fleet_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/posthog/duckgres/controlplane/admin"
 	"github.com/posthog/duckgres/controlplane/configstore"
 	"github.com/posthog/duckgres/controlplane/provisioner"
 	"github.com/posthog/duckgres/controlplane/provisioner/opa"
@@ -92,6 +93,9 @@ func TestTrinoRegistryOnlyBootstrapHasNoLegacyDependency(t *testing.T) {
 	wire := fleet[0]
 	wire.BundleStore.Set(opa.NewBundle([]byte("registered")))
 	engine.Any(wire.bundlePath(), gin.WrapH(wire.BundleHandler))
+	if err := admin.RegisterUI(engine); err != nil {
+		t.Fatal(err)
+	}
 	secret, err := kc.CoreV1().Secrets("trino-test").Get(context.Background(), provisioner.TrinoOPABundleTokenSecretName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)

--- a/controlplane/trino_fleet_test.go
+++ b/controlplane/trino_fleet_test.go
@@ -123,6 +123,7 @@ func (c *fleetCatalog) ListCatalogs(ctx context.Context) ([]string, error) {
 func (c *fleetCatalog) CreateCatalog(context.Context, string, map[string]string) error { return nil }
 func (c *fleetCatalog) AlterCatalog(context.Context, string, map[string]string) error  { return nil }
 func (c *fleetCatalog) DropCatalog(context.Context, string) error                      { return nil }
+func (c *fleetCatalog) ListNodes(context.Context) ([]provisioner.TrinoNode, error)     { return nil, nil }
 
 func TestTrinoFleetSlowCellDoesNotBlockSibling(t *testing.T) {
 	store := &fleetBootstrapStore{initialized: map[string]bool{}}

--- a/docs/runbooks/control-plane-rollout.md
+++ b/docs/runbooks/control-plane-rollout.md
@@ -9,17 +9,34 @@ Replace Duckgres control-plane replicas without breaking most existing sessions 
 - The Deployment uses rolling replacement with overlap:
   - `maxUnavailable: 0`
   - `maxSurge: 1`
-- `terminationGracePeriodSeconds` is at least the configured drain timeout
+- A `preStop` retirement hook keeps the listeners available while the
+  terminating pod is withdrawn from Service routing. The isolated E2E fixture
+  uses `exec: { command: ["sleep", "5"] }`; verify the corresponding lifecycle
+  setting in the deployment being rolled out.
+- `terminationGracePeriodSeconds` includes both the hook and the configured
+  drain timeout. The isolated fixture uses 35 seconds to preserve its previous
+  30-second drain budget after the five-second hook.
 - The control plane sets `--handover-drain-timeout 15m` (or another explicit value appropriate for the cluster)
 
 ## Expected behavior
 
-1. The old replica receives `SIGTERM`.
-2. It closes local pgwire admission and fails `/health`.
-3. It publishes `draining` in runtime state.
-4. New pgwire sessions are rejected on the draining replica.
-5. Existing pgwire connections continue until they finish or the drain timeout expires.
-6. When the timeout expires, the replica force-shuts down remaining sessions and workers.
+1. Kubernetes marks the old pod terminating and asynchronously withdraws it
+   from Service routing. The preStop hook keeps its listeners available during
+   this propagation window.
+2. After the hook, the old replica receives `SIGTERM`, closes local pgwire
+   admission, and fails `/health`.
+3. It publishes `draining` in runtime state. New pgwire sessions are rejected.
+4. Existing pgwire connections continue until they finish or the drain timeout
+   expires. With no connections, the process can exit immediately.
+5. When the timeout expires, the replica force-shuts down remaining sessions
+   and workers.
+
+`kubectl rollout status` observes Deployment replica counters; it does not
+confirm that the previous pods have finished terminating or that every client
+node has updated Service routing. Without a retirement hook, requests can
+still reach an old pod after its listener has closed. A hook alone also does
+not prove that a configuration read reaches the new revision: the old pod can
+still answer during that hook.
 
 See [Org connection admission](org-connection-admission.md) for the
 mixed-version admission boundary during a rolling deployment.
@@ -31,8 +48,9 @@ Unplanned control-plane failure is different:
 
 ## Rollout procedure
 
-1. Start the rollout.
+1. Capture the previous pods, then start the rollout.
    ```bash
+   old_pods="$(kubectl -n duckgres get pods -l app=duckgres-control-plane -o name)"
    kubectl -n duckgres rollout restart deploy/duckgres-control-plane
    kubectl -n duckgres rollout status deploy/duckgres-control-plane
    ```
@@ -48,7 +66,16 @@ Unplanned control-plane failure is different:
    kubectl -n duckgres logs <old-pod-name>
    ```
 
-4. Confirm the new pod is serving traffic and new sessions acquire workers.
+4. Before asserting that a configuration change is visible, wait for the
+   captured previous pods to finish retiring. Select a timeout that includes
+   the configured session-drain budget; long-lived sessions may keep them
+   alive. Do not wait on the label selector, which also selects the new pods.
+   ```bash
+   # Splitting is intentional: kubectl emitted one resource name per line.
+   kubectl -n duckgres wait --for=delete $old_pods --timeout=20m
+   ```
+
+5. Confirm the new pod is serving traffic and new sessions acquire workers.
    - `sum(duckgres_worker_lifecycle_count{state="spawning"})` settles back toward 0 (on-demand spawns succeed)
    - `sum(duckgres_worker_lifecycle_count{state="hot"})` does not drop unexpectedly
    - client reconnect errors do not spike
@@ -59,7 +86,10 @@ Unplanned control-plane failure is different:
   ```bash
   kubectl -n duckgres logs <old-pod-name> | rg "drain|draining|shutdown"
   ```
-- Check whether the pod termination grace period is shorter than the configured drain timeout.
+- Inspect pod events for `FailedPreStopHook` and verify the hook command exists
+  in the image.
+- Check whether the pod termination grace period includes both the hook and
+  the configured drain timeout.
 - Check whether long-lived idle clients are holding pgwire connections open.
 
 ## If the timeout is too short
@@ -69,3 +99,9 @@ Unplanned control-plane failure is different:
   - `terminationGracePeriodSeconds`
 
 Keep those values aligned. If the pod is killed before the drain timeout elapses, Kubernetes will cut the drain short.
+
+If new connections are refused immediately after rollout completion, collect
+old/new pod logs and EndpointSlice watches alongside client-node routing or
+packet evidence during the transition. Distinguish a reset from an exited old
+pod from a Service with no usable backend. Preserve the failure instead of
+retrying a configuration assertion until it happens to select the new pod.

--- a/docs/runbooks/trino-readiness.md
+++ b/docs/runbooks/trino-readiness.md
@@ -1,0 +1,68 @@
+# Trino tenant readiness
+
+Duckgres reports a tenant ready only after its catalog reconciles and its
+current metadata password has been observed in the mounted Secret on every
+active member of every configured running backend. This includes an active
+coordinator and at least one active worker. Successful `CREATE CATALOG` checks
+the coordinator; it does not acknowledge workers' independent Secret mounts.
+
+The provisioner queries `system.runtime.nodes`, matches member addresses to
+pods in the cell namespace, and runs a read-only SHA-256 check inside the Trino
+container. It compares hashes to the Secret bytes written during that reconcile.
+Passwords and hashes are never logged or placed in status messages. A missing
+or stale file leaves only the affected tenant `provisioning`. API, permission,
+malformed response, or mount configuration errors fail readiness explicitly.
+Pod replacements, restarts, and membership changes during the check defer
+readiness to the next reconcile.
+
+This records observed credential readiness. It is not a guarantee against a
+worker joining or failing afterward, proof that every lazy catalog has loaded,
+or an end-to-end Gateway health check. Membership and files are checked again
+on every reconcile, including for existing catalogs and ready tenants.
+
+## Deployment requirements
+
+- Apply namespace-scoped `pods` `get`/`list` and `pods/exec` `create` permissions
+  for the control-plane service account before deploying this code. Kubernetes
+  grants exec capability; the provisioner uses it only for the fixed read-only
+  observation command.
+- Mount `trino-tenant-secrets` read-only as a whole Secret volume in every Trino
+  container. The default mount is `/etc/trino/tenant-secrets`; an explicit
+  `DUCKGRES_TRINO_TENANT_SECRET_MOUNT_PATH` must match the actual mount. A
+  `subPath` mount cannot receive projected Secret updates and is rejected.
+- The Trino image must contain `/bin/sh` and `sha256sum`. Member HTTP URIs must
+  identify pod IPs in that namespace. Ambiguous container mappings are rejected.
+- Publish the updated Duckgres OPA bundle. The provisioner administrator needs
+  narrow read access to `system.runtime.nodes`; tenant access remains denied.
+
+Checks batch at most 128 tenant files per exec and use at most four concurrent
+execs per backend. Each exec has a five-second deadline within the existing
+30-second backend reconciliation budget and 90-second cell API budget. These
+are fixed defaults, with no readiness bypass flag. Stopped backends are skipped.
+
+## Local verification
+
+Run `just test-trino`, `just test-controlplane-k8s`, `just test-mw-fixtures`, and
+`just lint`. The readiness regressions reproduce successful coordinator catalog
+creation while a worker still has missing or stale credentials, then verify the
+transition to ready once that worker observes the current file. Tests also cover
+multiple running backends, member replacement, exec failures, and timeouts.
+
+Run the isolated Trino CI lane for the real Kubernetes projection and query
+path. It waits for the existing Duckgres readiness API and immediately performs
+tenant queries; do not add sleeps or query retries to hide provisioning errors.
+
+## Recovery
+
+For `provisioning`, read the status message and inspect active membership and
+pod readiness in the affected cell. Missing or stale files should recover on
+the next reconcile after Kubelet projects the Secret. Do not print Secret
+contents or hashes while diagnosing projection lag.
+
+For a failed observation, check the control-plane service account's namespaced
+pod read/exec permissions, API connectivity, the Trino container's mount path,
+and the required shell utilities. For a denied node inventory query, verify the
+OPA bundle has refreshed and the provisioner identity is authenticated. Correct
+the configuration and allow reconciliation to retry. Keep Trino's missing-file
+catalog validation enabled; do not bypass readiness or mark the tenant ready
+manually.

--- a/docs/trino-cells.md
+++ b/docs/trino-cells.md
@@ -65,6 +65,9 @@ deployment-managed internal-communication Secrets. Duckgres reads those
 references and refuses missing keys; it never creates or modifies them.
 They must exist even for a stopped backend. Grant the control-plane service
 account the corresponding namespace-scoped projection permissions first.
+Mounted credential readiness additionally requires `get`/`list` on `pods` and
+`create` on `pods/exec` in each Trino namespace. Apply those chart permissions
+before deploying the readiness-aware control plane.
 
 New-cell OPA sidecars poll `/bundles/trino/<cell-id>` with that namespace's
 bundle token. Legacy keeps `/bundles/trino`. Tokens cannot read another cell's
@@ -107,6 +110,13 @@ or live observer polls. A stopped green does not make blue's tenants unhealthy.
 When green starts, update the registry and restart the control plane. Every
 running backend must reconcile successfully before a tenant is reported ready;
 one successful coordinator cannot conceal another's missing catalog or failure.
+Catalog creation is followed by a check of the current tenant password file on
+every active member reported by `system.runtime.nodes`, including a coordinator
+and at least one worker. Node and pod identities are checked again after the
+observation; replacements or projection lag keep the tenant `provisioning`.
+Existing catalogs undergo the same check on every reconcile. See the
+[readiness runbook](runbooks/trino-readiness.md) for the precise contract and
+failure recovery.
 The console observes the configured routing-active backend. Usage collection
 polls each running backend independently under the existing leader lease.
 

--- a/docs/trino-cells.md
+++ b/docs/trino-cells.md
@@ -72,6 +72,8 @@ before deploying the readiness-aware control plane.
 New-cell OPA sidecars poll `/bundles/trino/<cell-id>` with that namespace's
 bundle token. Legacy keeps `/bundles/trino`. Tokens cannot read another cell's
 bundle. The observer credential remains separate from the catalog administrator.
+In registry-only mode, `/bundles/trino` is absent and returns HTTP 404. Missing
+bundle URLs never fall back to the admin UI page.
 
 ## Initial assignment
 

--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -126,9 +127,11 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
+	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.1.25 // indirect

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,8 @@ github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyC
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -281,6 +283,8 @@ github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8D
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
+github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
+github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/sys/user v0.4.0 h1:jhcMKit7SA80hivmFJcbB1vqmw//wU61Zdui2eQXuMs=
 github.com/moby/sys/user v0.4.0/go.mod h1:bG+tYYYJgaMtRKgEmuueC0hJEAZWwtIbZTB+85uoHjs=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
@@ -293,6 +297,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=

--- a/tests/mw-dev/README.md
+++ b/tests/mw-dev/README.md
@@ -57,6 +57,31 @@ The isolated control plane's default worker request is configurable through
 `scenario-dev.yml` explicitly overrides them to 3 CPU and 12Gi for the frozen
 perf workload. Direct `run.sh` callers can make the same explicit override.
 
+### Control-plane rollout retirement
+
+The isolated Deployment uses `maxUnavailable: 0`, `maxSurge: 1`, a five-second
+`preStop` hook, and `terminationGracePeriodSeconds: 35`. These are explicit
+fixture settings: the hook keeps the API listening while Kubernetes withdraws
+the terminating pod from Service routing, then leaves the previous 30-second
+budget for session drain after SIGTERM. An idle control plane can otherwise
+exit before client-node routing updates and reject a post-rollout connection.
+
+Trino configuration transitions capture the old pod names before each patch,
+wait for Deployment rollout completion, then wait for those exact pods to be
+deleted. Each wait is bounded at 180 seconds. Deployment replica counters alone
+can report success while a previous pod is still running its retirement hook
+and serving the previous configuration. The cells assertion remains a single
+authenticated request; transport failures and incorrect cell contents both
+fail the test, with distinct diagnostics.
+
+Run `just test-mw-fixtures` locally to exercise retirement ordering and error
+handling without a cluster. For a stalled live transition, inspect the named
+old pods and their events/logs for a stuck hook or session drain. Do not force
+delete them or add retries to the content assertion. For connection failures,
+capture old/new pod logs, EndpointSlice transitions, and client-node Service
+routing during the rollout; post-failure pod readiness alone misses the race.
+See [Control-plane rollout](../../docs/runbooks/control-plane-rollout.md).
+
 ### Scenario Trino readiness
 
 Scenarios that opt an org into Trino in their `provision_warehouse` request can

--- a/tests/mw-dev/controlplane_retirement_test.go
+++ b/tests/mw-dev/controlplane_retirement_test.go
@@ -1,0 +1,54 @@
+package e2emwdev_test
+
+import (
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func TestControlPlaneRetirementPreservesRoutingWithdrawalWindow(t *testing.T) {
+	raw, err := os.ReadFile("manifests.tmpl.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := os.Expand(string(raw), func(string) string { return "fixture-value" })
+	decoder := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(rendered), 4096)
+	for {
+		var manifest map[string]any
+		if err := decoder.Decode(&manifest); err == io.EOF {
+			t.Fatal("control-plane Deployment not found")
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		if manifest["kind"] != "Deployment" || manifestName(manifest) != "duckgres-control-plane" {
+			continue
+		}
+		deployment := manifest["spec"].(map[string]any)
+		pod := deployment["template"].(map[string]any)["spec"].(map[string]any)
+		container := pod["containers"].([]any)[0].(map[string]any)
+		lifecycle, ok := container["lifecycle"].(map[string]any)
+		if !ok {
+			t.Fatal("idle control plane can exit before Service routing withdraws: missing preStop lifecycle")
+		}
+		preStop, _ := lifecycle["preStop"].(map[string]any)
+		exec, _ := preStop["exec"].(map[string]any)
+		if got := stringSlice(exec["command"]); !reflect.DeepEqual(got, []string{"sleep", "5"}) {
+			t.Fatalf("preStop must leave the listener serving for the documented 5-second withdrawal window, got %v", got)
+		}
+		// The hook runs inside the pod's grace budget. Preserve the previous
+		// default 30 seconds for PG drain after its five-second hook.
+		if grace, _ := pod["terminationGracePeriodSeconds"].(float64); grace < 35 {
+			t.Fatalf("termination budget must include withdrawal plus the existing 30-second drain budget, got %v", grace)
+		}
+		strategy, _ := deployment["strategy"].(map[string]any)
+		rolling, _ := strategy["rollingUpdate"].(map[string]any)
+		if strategy["type"] != "RollingUpdate" || rolling["maxUnavailable"] != float64(0) || rolling["maxSurge"] != float64(1) {
+			t.Fatalf("single-replica control plane must retain overlap during retirement, got %v", strategy)
+		}
+		return
+	}
+}

--- a/tests/mw-dev/e2e/trino-multicell.sh
+++ b/tests/mw-dev/e2e/trino-multicell.sh
@@ -1,5 +1,22 @@
 #!/bin/sh
 # The main Trino harness supplies authenticated API and SQL helpers.
+# Keep the exact retiring replicas: rollout status can succeed while their
+# preStop hooks still serve the previous configuration.
+snapshot_control_plane_pods() {
+  old_control_plane_pods="$("$KUBECTL" -n "$NS" get pods -l app=duckgres-control-plane -o name)" \
+    || fail "could not snapshot control-plane pods before rollout"
+  [ -n "$old_control_plane_pods" ] || fail "no control-plane pods before rollout"
+}
+wait_control_plane_rollout() {
+  "$KUBECTL" -n "$NS" rollout status deployment/duckgres-control-plane --timeout=180s >/dev/null \
+    || fail "control-plane rollout failed"
+  # Intentional word splitting of kubectl's newline-separated resource names.
+  # The fixed snapshot excludes replacement pods and includes all old replicas.
+  # shellcheck disable=SC2086
+  "$KUBECTL" -n "$NS" wait --for=delete $old_control_plane_pods --timeout=180s >/dev/null \
+    || fail "old control-plane pods did not terminate after rollout"
+}
+
 CELL_NS="${TRINO_CELL_NAMESPACE:?}"
 ORG_C="ci-pr-${PR}-trinoc"
 DB_C="trino-c-${PR}"
@@ -91,9 +108,10 @@ log "green catalog hydration"
 registry="$("$KUBECTL" -n "$NS" get configmap trino-cell-registry -o json \
   | jq -r '.data["cells.json"]' | jq '.cells[0].backends |= map(if .id == "green" then .running=true else . end)')"
 patch="$(printf %s "$registry" | jq -Rs '{data:{"cells.json":.}}')"
+snapshot_control_plane_pods
 "$KUBECTL" -n "$NS" patch configmap trino-cell-registry --type=merge -p "$patch" >/dev/null
 "$KUBECTL" -n "$NS" rollout restart deployment/duckgres-control-plane >/dev/null
-"$KUBECTL" -n "$NS" rollout status deployment/duckgres-control-plane --timeout=180s >/dev/null
+wait_control_plane_rollout
 for target in coordinator worker; do
   "$KUBECTL" -n "$CELL_NS" patch deployment "duckgres-trino-green-$target" --type=merge -p '{"spec":{"replicas":1}}' >/dev/null
 done
@@ -127,10 +145,12 @@ log "registry-only startup without legacy"
 legacy_env="$("$KUBECTL" -n "$NS" get deployment duckgres-control-plane -o json | jq -c '.spec.template.spec.containers[] | select(.name == "controlplane") | .env[] | select(.name == "DUCKGRES_TRINO_COORDINATOR_URL")')"
 [ -n "$legacy_env" ] || fail "missing legacy configuration before registry-only test"
 legacy_owner="$(api "$API/api/v1/orgs/$ORG_A" | jq -r .trino.trino_cell_id)"
+snapshot_control_plane_pods
 "$KUBECTL" -n "$NS" patch deployment duckgres-control-plane --type=strategic -p \
   '{"spec":{"template":{"spec":{"containers":[{"name":"controlplane","env":[{"name":"DUCKGRES_TRINO_COORDINATOR_URL","$patch":"delete"},{"name":"DUCKGRES_TRINO_REGISTRY_ONLY","value":"true"}]}]}}}}' >/dev/null
-"$KUBECTL" -n "$NS" rollout status deployment/duckgres-control-plane --timeout=180s >/dev/null
-api "$API/api/v1/trino/cells" | jq -e '.cells | map(.id) == ["cell-test"]' >/dev/null \
+wait_control_plane_rollout
+cells="$(api "$API/api/v1/trino/cells")" || fail "registry-only cells API request failed"
+printf %s "$cells" | jq -e '.cells | map(.id) == ["cell-test"]' >/dev/null \
   || fail "registry-only startup invented a legacy cell"
 wait_cell_ready
 for endpoint in "$BLUE_TRINO" "$GREEN_TRINO"; do
@@ -160,8 +180,9 @@ api "$API/api/v1/orgs/ci-pr-$PR-unassigned/trino" \
 
 log "restore legacy fixture configuration"
 patch="$(printf %s "$legacy_env" | jq -c '{spec:{template:{spec:{containers:[{name:"controlplane",env:[.,{name:"DUCKGRES_TRINO_REGISTRY_ONLY","$patch":"delete"}]}]}}}}')"
+snapshot_control_plane_pods
 "$KUBECTL" -n "$NS" patch deployment duckgres-control-plane --type=strategic -p "$patch" >/dev/null
-"$KUBECTL" -n "$NS" rollout status deployment/duckgres-control-plane --timeout=180s >/dev/null
+wait_control_plane_rollout
 TRINO="$LEGACY_TRINO"
 [ "$(trino_query "$DB_A" "$pw_a" 'SELECT 1')" = '[[1]]' ] || fail "legacy query failed after registry-only fixture restore"
 log "PASS: registry-only startup + explicit selection + no legacy dependency + restored fixture"

--- a/tests/mw-dev/manifests.tmpl.yaml
+++ b/tests/mw-dev/manifests.tmpl.yaml
@@ -156,6 +156,10 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["create", "delete", "get", "list", "watch", "patch"]
+  # The control plane checks Trino's mounted tenant credentials before readiness.
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
   - apiGroups: [""]
     resources: ["pods/log"]
     verbs: ["get"]

--- a/tests/mw-dev/manifests.tmpl.yaml
+++ b/tests/mw-dev/manifests.tmpl.yaml
@@ -265,6 +265,9 @@ metadata:
   namespace: ${NAMESPACE}
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate: { maxUnavailable: 0, maxSurge: 1 }
   selector:
     matchLabels: { app: duckgres-control-plane }
   template:
@@ -280,11 +283,20 @@ spec:
         karpenter.sh/do-not-disrupt: "true"
     spec:
       serviceAccountName: duckgres
+      # The hook consumes five seconds; retain the previous default 30-second
+      # budget for the control plane's session drain after SIGTERM.
+      terminationGracePeriodSeconds: 35
       containers:
         - name: controlplane
           image: ${CONTROLPLANE_IMAGE}
           imagePullPolicy: IfNotPresent
           args: ["--mode", "control-plane", "--worker-backend", "remote"]
+          lifecycle:
+            preStop:
+              # Pod termination withdraws its Service endpoint asynchronously.
+              # Keep the API listening while client-node routing catches up;
+              # an idle control plane otherwise exits immediately on SIGTERM.
+              exec: { command: ["sleep", "5"] }
           env:
             # Pod identity for log stamping: the shared logging handler attaches
             # pod=/node= to every line when these are set (workers get them via

--- a/tests/mw-dev/trino-multicell.tmpl.yaml
+++ b/tests/mw-dev/trino-multicell.tmpl.yaml
@@ -39,6 +39,13 @@ metadata:
   name: trino-cell-projection
   namespace: ${TRINO_CELL_NAMESPACE}
 rules:
+  # Verify credentials in the cell's Trino pods before reporting tenant readiness.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
   - apiGroups: [""]
     resources: ["secrets", "configmaps"]
     verbs: ["create"]

--- a/tests/mw-dev/trino_readiness_rbac_test.go
+++ b/tests/mw-dev/trino_readiness_rbac_test.go
@@ -1,0 +1,92 @@
+package e2emwdev_test
+
+import (
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func TestTrinoSecretReadinessPermissions(t *testing.T) {
+	for _, fixture := range []struct {
+		file      string
+		role      string
+		namespace string
+	}{
+		{"manifests.tmpl.yaml", "duckgres-control-plane", "suite-test"},
+		{"trino-multicell.tmpl.yaml", "trino-cell-projection", "cell-test"},
+	} {
+		t.Run(fixture.role, func(t *testing.T) {
+			raw, err := os.ReadFile(fixture.file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rendered := os.Expand(string(raw), func(name string) string {
+				switch name {
+				case "NAMESPACE":
+					return "suite-test"
+				case "TRINO_CELL_NAMESPACE":
+					return "cell-test"
+				default:
+					return "fixture-value"
+				}
+			})
+			decoder := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(rendered), 4096)
+			var rules []rbacv1.PolicyRule
+			bound := false
+			for {
+				var object struct {
+					Kind     string              `json:"kind"`
+					Metadata metav1.ObjectMeta   `json:"metadata"`
+					Rules    []rbacv1.PolicyRule `json:"rules"`
+					Subjects []rbacv1.Subject    `json:"subjects"`
+					RoleRef  rbacv1.RoleRef      `json:"roleRef"`
+				}
+				if err := decoder.Decode(&object); err == io.EOF {
+					break
+				} else if err != nil {
+					t.Fatal(err)
+				}
+				if object.Metadata.Namespace != fixture.namespace {
+					continue
+				}
+				if object.Kind == "Role" && object.Metadata.Name == fixture.role {
+					rules = object.Rules
+				}
+				if object.Kind == "RoleBinding" && object.RoleRef.Kind == "Role" && object.RoleRef.Name == fixture.role {
+					for _, subject := range object.Subjects {
+						if subject.Kind == "ServiceAccount" && subject.Name == "duckgres" && subject.Namespace == "suite-test" {
+							bound = true
+						}
+					}
+				}
+			}
+			if !bound {
+				t.Fatal("readiness permissions must be bound to the control-plane ServiceAccount")
+			}
+			for _, request := range []struct{ resource, verb string }{
+				{"pods", "get"}, {"pods", "list"}, {"pods/exec", "create"},
+			} {
+				allowed := false
+				for _, rule := range rules {
+					if slices.Contains(rule.APIGroups, "") && slices.Contains(rule.Resources, request.resource) && slices.Contains(rule.Verbs, request.verb) && len(rule.ResourceNames) == 0 {
+						allowed = true
+					}
+				}
+				if !allowed {
+					t.Errorf("control plane cannot %s %s in %s to verify mounted Trino credentials", request.verb, request.resource, fixture.namespace)
+				}
+			}
+			for _, rule := range rules {
+				if slices.Contains(rule.Resources, "pods/exec") && (!slices.Equal(rule.Verbs, []string{"create"}) || !slices.Equal(rule.APIGroups, []string{""}) || !slices.Equal(rule.Resources, []string{"pods/exec"})) {
+					t.Errorf("pod exec grant must be limited to creating exec requests: %+v", rule)
+				}
+			}
+		})
+	}
+}

--- a/tests/mw-dev/trino_rollout_test.go
+++ b/tests/mw-dev/trino_rollout_test.go
@@ -1,0 +1,110 @@
+package e2emwdev_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Run the real registry-only phase: rollout completion leaves the old revision
+// serving during preStop, so configuration assertions must await its deletion.
+func TestTrinoRegistryOnlyRolloutHandoff(t *testing.T) {
+	raw, err := os.ReadFile("e2e/trino-multicell.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(raw)
+	helpersEnd := strings.Index(script, "CELL_NS=")
+	phaseStart := strings.Index(script, `log "registry-only startup without legacy"`)
+	if helpersEnd < 0 || phaseStart < 0 {
+		t.Fatal("missing real registry-only phase")
+	}
+	phaseEnd := strings.Index(script[phaseStart:], "\nwait_cell_ready") + phaseStart
+	if phaseEnd < phaseStart {
+		t.Fatal("missing real registry-only phase")
+	}
+	for _, tc := range []struct{ name, failure, cells, want string }{
+		{"old revision finishes before assertion", "", `{"cells":[{"id":"cell-test"}]}`, ""},
+		{"snapshot fails", "snapshot", "", "snapshot control-plane pods"},
+		{"empty snapshot fails", "empty", "", "no control-plane pods"},
+		{"rollout fails", "rollout", "", "control-plane rollout failed"},
+		{"old pod deletion times out", "delete", "", "old control-plane pods did not terminate"},
+		{"transport fails", "transport", "", "registry-only cells API request failed"},
+		{"legacy cell remains", "", `{"cells":[{"id":"cell-test"},{"id":"legacy"}]}`, "registry-only startup invented a legacy cell"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			calls := filepath.Join(dir, "calls")
+			writeFake(t, dir, "kubectl", `#!/bin/sh
+printf 'kubectl %s\n' "$*" >> "$ROLLOUT_TEST_CALLS"
+case "$*" in
+ *"get deployment duckgres-control-plane -o json") printf '%s\n' '{"spec":{"template":{"spec":{"containers":[{"name":"controlplane","env":[{"name":"DUCKGRES_TRINO_COORDINATOR_URL","value":"http://legacy.invalid"}]}]}}}}' ;;
+ *"get pods -l app=duckgres-control-plane -o name")
+  [ "$ROLLOUT_TEST_FAILURE" != snapshot ] || exit 1
+  [ "$ROLLOUT_TEST_FAILURE" != empty ] || exit 0
+  printf 'pod/control-plane-old-a\npod/control-plane-old-b\n' ;;
+ *"patch deployment duckgres-control-plane"*) ;;
+ *"rollout status deployment/duckgres-control-plane --timeout=180s")
+  [ "$ROLLOUT_TEST_FAILURE" != rollout ] || exit 1 ;;
+ *"wait --for=delete pod/control-plane-old-a pod/control-plane-old-b --timeout=180s")
+  [ "$ROLLOUT_TEST_FAILURE" != delete ] || exit 1
+  touch "$ROLLOUT_TEST_DELETED" ;;
+ *) echo "unexpected kubectl: $*" >&2; exit 1 ;;
+esac
+`)
+			writeFake(t, dir, "curl", `#!/bin/sh
+printf 'curl %s\n' "$*" >> "$ROLLOUT_TEST_CALLS"
+case "$*" in
+ */api/v1/orgs/test-org) printf '%s\n' '{"trino":{"trino_cell_id":"legacy"}}' ;;
+ */api/v1/trino/cells)
+  [ -f "$ROLLOUT_TEST_DELETED" ] || { echo 'assertion reached retired revision' >&2; exit 99; }
+  [ "$ROLLOUT_TEST_FAILURE" != transport ] || { echo 'curl: (7) connection refused' >&2; exit 7; }
+  printf '%s\n' "$ROLLOUT_TEST_CELLS" ;;
+ *) exit 1 ;;
+esac
+`)
+			harness := `set -eu
+log() { :; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+api() { curl -fsS "$@"; }
+NS=test-namespace
+ORG_A=test-org
+API=http://control-plane.invalid
+` + script[:helpersEnd] + script[phaseStart:phaseEnd]
+			cmd := exec.Command("sh", "-c", harness)
+			cmd.Env = append(os.Environ(), "PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"), "KUBECTL="+filepath.Join(dir, "kubectl"), "ROLLOUT_TEST_CALLS="+calls, "ROLLOUT_TEST_DELETED="+filepath.Join(dir, "deleted"), "ROLLOUT_TEST_FAILURE="+tc.failure, "ROLLOUT_TEST_CELLS="+tc.cells)
+			out, runErr := cmd.CombinedOutput()
+			if tc.want == "" && runErr != nil {
+				t.Fatalf("handoff: %v\n%s", runErr, out)
+			}
+			if tc.want != "" && (runErr == nil || !strings.Contains(string(out), tc.want)) {
+				t.Fatalf("want failure %q; got %v\n%s", tc.want, runErr, out)
+			}
+			if tc.failure == "transport" && strings.Contains(string(out), "invented a legacy cell") {
+				t.Fatal("transport failure misreported as configuration failure")
+			}
+			callsRaw, err := os.ReadFile(calls)
+			if err != nil {
+				t.Fatal(err)
+			}
+			trace := string(callsRaw)
+			if tc.failure == "" || tc.failure == "transport" {
+				previous := -1
+				for _, step := range []string{"get pods", "patch deployment", "rollout status", "wait --for=delete", "/api/v1/trino/cells"} {
+					index := strings.Index(trace, step)
+					if index <= previous {
+						t.Fatalf("step %q missing or out of order:\n%s", step, trace)
+					}
+					previous = index
+				}
+				if strings.Count(trace, "/api/v1/trino/cells") != 1 {
+					t.Fatal("configuration assertion must use one request without retries")
+				}
+			} else if strings.Contains(trace, "/api/v1/trino/cells") {
+				t.Fatalf("failed rollout reached behavioral assertion:\n%s", trace)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Duckgres could report a Trino tenant ready as soon as its coordinator created the catalog, while a worker still lacked the tenant's metadata password file. The next query then failed during the worker's catalog initialization. Gate readiness on observing the current credential files across the active coordinator and workers of every running backend, including when the catalog already exists. Projection lag remains `provisioning`; observation failures are reported explicitly.

The provisioner reads `system.runtime.nodes`, matches members to their namespace pods, and compares mounted credential hashes against the Secret payload from the same reconcile. It rechecks node and pod identities afterward so replacements invalidate the observation. Checks are bounded, and credentials, hashes, and remote output are never logged. OPA grants the provisioner only the additional node inventory access it needs. Trino's missing-file validation remains intact.

The isolated E2E manifests in this PR include the required namespace-scoped pod read/exec permissions, so the CI fix is self-contained. [PostHog/charts#15595](https://github.com/PostHog/charts/pull/15595) separately supplies these permissions for shared deployments. The readiness runbook documents the runtime requirements.

The isolated control-plane deployment also uses a five-second `preStop` routing-withdrawal allowance, preserving its drain budget with a 35-second grace period. The Trino harness captures old pod names and waits for their retirement before its configuration assertions, so those assertions reach the new revision. It does not add retries or sleeps around tenant queries.

Missing `/bundles` URLs return HTTP 404 instead of the admin UI's HTML fallback. This preserves the registry-only contract that the legacy bundle route is absent. The existing registry-only test now includes the real UI router so it exercises the shipped server composition.

Validation:
- Red/green readiness regressions reproduce successful coordinator catalog creation with a lagging worker, then verify the transition to ready once projection completes.
- Coverage includes existing catalogs, multiple running backends, member replacement/reordering, preserved tenant failures, malformed observations, permissions, and bounded execution.
- `just test-controlplane-k8s`, focused Trino readiness/node tests, OPA policy tests, and `just test-mw-fixtures` pass.
- The concurrent credential checker passes the Go race detector and a real shell test covering 260 files across batches.
- `just lint` passes using CI's pinned toolchain; additional Kubernetes-tagged lint reports no new issues.
- The original isolated rollout reproduction passed 876 continuous health probes after the lifecycle fix.
- Live CI observed coordinator catalog success followed by about 31 seconds of worker credential lag; Duckgres kept the affected tenant provisioning until the mounted file caught up, then the unchanged distributed queries passed. The multi-cell case independently exercised the same wait, and green-backend startup passed.
- The real-router regression reproduces HTTP 200 before the missing-bundle fix and verifies HTTP 404 afterward. The running final image also returns JSON 404 for an unconfigured bundle URL.
- [Main CI](https://github.com/PostHog/duckgres/actions/runs/34697065003) and all four [E2E lanes](https://github.com/PostHog/duckgres/actions/runs/34697065137) pass on `eb6ef5cd`. The complete Trino lane passes provisioning, real reads/writes, isolation, hot-add, rotation, restarts, disable, multi-cell placement, green hydration, registry-only startup, and restored legacy queries.
