### PR TITLE
Preserve frozen perf corpus and add optional properties comparisons

### DIFF
--- a/.github/workflows/scenario-dev.yml
+++ b/.github/workflows/scenario-dev.yml
@@ -66,6 +66,7 @@ jobs:
     timeout-minutes: 270
     env:
       SCENARIO_NAME: ${{ matrix.scenario }}
+      DUCKGRES_SCENARIO_PROPERTIES_MANIFEST: ${{ secrets.DUCKGRES_PROPERTIES_MANIFEST_URI }}
       SCENARIO_RUNNER_IMAGE: ${{ needs.scenario-runner-image.outputs.image }}
       WORKER_IMAGE: ${{ (github.event_name == 'workflow_dispatch' && inputs.duckgres_image) || needs.duckgres-image.outputs.image }}
       CONTROLPLANE_IMAGE: ${{ (github.event_name == 'workflow_dispatch' && inputs.duckgres_image) || needs.duckgres-image.outputs.image }}
@@ -78,7 +79,7 @@ jobs:
       # consumed only when E2E_SUITE selects that isolated deployment.
       TRINO_POD_IDENTITY_ROLE: ${{ secrets.MW_DEV_TRINO_POD_IDENTITY_ROLE }}
       TRINO_IMAGE: ghcr.io/posthog/trino:59184e0c58c2fdbde031f3a08787c926dc4d7f69@sha256:a7072f7c86fcbb815c2502bb455b27bc4679d201ad6ce81725378a7c5ce84325
-      E2E_SUITE: ${{ (matrix.scenario == 'posthog_frozen_perf' || matrix.scenario == 'posthog_frozen_perf_trino_cached') && 'trino' || 'neutral' }}
+      E2E_SUITE: ${{ (matrix.scenario == 'posthog_frozen_perf' || matrix.scenario == 'posthog_frozen_perf_trino_cached' || matrix.scenario == 'posthog_properties_perf') && 'trino' || 'neutral' }}
       PR_NUMBER: ${{ github.run_id }}${{ strategy.job-index }}
       NAMESPACE: duckgres-ci-pr-${{ github.run_id }}${{ strategy.job-index }}
       DUCKGRES_SCENARIO_MAX_RUNTIME: 4h
@@ -129,7 +130,7 @@ jobs:
         run: aws eks update-kubeconfig --name "$CLUSTER_NAME" --region "$AWS_REGION" --alias "$KUBE_CONTEXT"
 
       - name: Load Athena perf configuration
-        if: env.SCENARIO_NAME == 'posthog_frozen_perf'
+        if: env.SCENARIO_NAME == 'posthog_frozen_perf' || env.SCENARIO_NAME == 'posthog_properties_perf'
         run: bash scripts/scenario_athena_config.sh >> "$GITHUB_ENV"
 
       - name: Deploy isolated Duckgres stack

--- a/.github/workflows/scenario-dev.yml
+++ b/.github/workflows/scenario-dev.yml
@@ -66,7 +66,6 @@ jobs:
     timeout-minutes: 270
     env:
       SCENARIO_NAME: ${{ matrix.scenario }}
-      DUCKGRES_SCENARIO_PROPERTIES_MANIFEST: ${{ secrets.DUCKGRES_PROPERTIES_MANIFEST_URI }}
       SCENARIO_RUNNER_IMAGE: ${{ needs.scenario-runner-image.outputs.image }}
       WORKER_IMAGE: ${{ (github.event_name == 'workflow_dispatch' && inputs.duckgres_image) || needs.duckgres-image.outputs.image }}
       CONTROLPLANE_IMAGE: ${{ (github.event_name == 'workflow_dispatch' && inputs.duckgres_image) || needs.duckgres-image.outputs.image }}

--- a/cmd/perf-properties-prepare/main.go
+++ b/cmd/perf-properties-prepare/main.go
@@ -1,0 +1,85 @@
+// perf-properties-prepare validates a published fixture and emits private run inputs.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/posthog/duckgres/tests/perf/properties"
+	"gopkg.in/yaml.v3"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+func run() error {
+	manifest := flag.String("manifest", "", "Required local path or s3:// completion manifest")
+	output := flag.String("output-dir", "", "Required private output directory")
+	athenaDB := flag.String("athena-database", "", "Optional existing Athena database; enables read-only table verification")
+	athenaRegion := flag.String("athena-region", "", "AWS region for Athena Glue metadata; defaults to SDK region")
+	athenaTable := flag.String("athena-table", "properties_events_supported", "Existing Athena table (catalog currently requires properties_events_supported)")
+	flag.Parse()
+	if *manifest == "" || *output == "" {
+		return fmt.Errorf("-manifest and -output-dir are required")
+	}
+	if *athenaTable != "properties_events_supported" {
+		return fmt.Errorf("-athena-table must be properties_events_supported to match the catalog")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return err
+	}
+	client := s3.NewFromConfig(cfg)
+	var m *properties.Manifest
+	if strings.HasPrefix(*manifest, "s3://") {
+		m, err = properties.LoadS3(ctx, client, *manifest)
+	} else {
+		m, err = properties.Load(*manifest)
+	}
+	if err != nil {
+		return err
+	}
+	if err = m.VerifyInventory(ctx, client); err != nil {
+		return err
+	}
+	if *athenaDB != "" {
+		glueCfg := cfg
+		if *athenaRegion != "" {
+			glueCfg.Region = *athenaRegion
+		}
+		if err = m.VerifyAthenaTable(ctx, glue.NewFromConfig(glueCfg), *athenaDB, *athenaTable); err != nil {
+			return err
+		}
+	}
+	athenaSQL, err := m.AthenaSQL(*athenaTable)
+	if err != nil {
+		return err
+	}
+	catalog, err := yaml.Marshal(properties.Catalog(m))
+	if err != nil {
+		return err
+	}
+	if err = os.MkdirAll(*output, 0700); err != nil {
+		return err
+	}
+	for name, data := range map[string][]byte{"setup.sql": []byte(m.SetupSQL()), "athena.sql": []byte(athenaSQL), "catalog.yaml": catalog, "dataset-version.txt": []byte("properties-v3-sha256-" + m.SHA256 + "\n")} {
+		if err = os.WriteFile(filepath.Join(*output, name), data, 0600); err != nil {
+			return err
+		}
+	}
+	fmt.Printf("Validated manifest and %d objects; value validation remains sampled until paired query checks pass.\n", len(m.Files))
+	return nil
+}

--- a/docs/perf-harness-runbook.md
+++ b/docs/perf-harness-runbook.md
@@ -151,9 +151,11 @@ Rows are stored with:
 - `dataset_version`
 - `run_date`
 
-The source CSV schema is fixed to:
+The current source CSV schema is:
 
-`query_id,intent_id,measure_iteration,protocol,status,error,error_class,rows,duration_ms,started_at`
+`query_id,intent_id,measure_iteration,protocol,status,error,error_class,rows,duration_ms,started_at,representation`
+
+The publisher also accepts the original header without `representation`. Schema bootstrap adds the nullable `representation` column to existing result tables; deployments with bootstrap disabled must apply that additive migration before publishing. Existing workloads use an empty label. Properties query IDs retain their representation suffix for existing dashboard grouping.
 
 `summary.json` remains a local run artifact and is also consumed by the publisher to populate run-level dashboard metadata.
 For frozen runs, `dataset_manifest.json` is written and validated by the harness before publisher writes begin.

--- a/docs/runbooks/properties-perf.md
+++ b/docs/runbooks/properties-perf.md
@@ -1,0 +1,70 @@
+# Published properties performance workload
+
+The `posthog_properties_perf` scenario compares JSON and STRUCT on DuckDB,
+Trino, and Athena, plus VARIANT on DuckDB, using the same published Parquet
+files. It provisions and removes an isolated warehouse. Existing full-corpus
+queries and the scheduled workflow selection are unchanged.
+
+## Prepare and run
+
+Set `DUCKGRES_SCENARIO_PROPERTIES_MANIFEST` to the private S3 URI of the
+published `complete.json`. Keep operational configuration and generated files
+outside this public repository. Never select incomplete output with a wildcard.
+
+`just prepare-properties-perf "$DUCKGRES_SCENARIO_PROPERTIES_MANIFEST"` validates
+the fixture and writes `setup.sql`, `athena.sql`, `catalog.yaml`, and
+`dataset-version.txt` to `/tmp/properties-perf` by default. Its second argument
+overrides that directory. Preparation reads the published fixture; it does not
+generate or rewrite source data. Completion-manifest value checks are sampled;
+the workload's full query-result comparisons provide a separate correctness gate.
+
+An operator with Glue table-creation permission must provision
+`properties_events_supported` in the configured Athena database using the
+generated `athena.sql` before running. This logical schema omits VARIANT while
+pointing at the same physical fixture. The ordinary scenario identity has
+read-only Glue access. Do not expand its privileges or replace existing shared
+benchmark tables to bypass a setup failure.
+
+With an explicitly configured disposable warehouse identity and the environment
+required by the scenario YAML, run:
+
+```sh
+just scenario-properties-perf
+```
+
+The runner prepares the fixture before provisioning, verifies the Athena table
+against the selected fixture, and exports its manifest-derived dataset version.
+`DUCKGRES_SCENARIO_PROPERTIES_OUTPUT_DIR` overrides `/tmp/properties-perf`;
+relative paths are resolved from the repository root. `--check-env` checks
+required settings without reading S3, preparing files, or provisioning.
+
+Configure the repository Actions secret `DUCKGRES_PROPERTIES_MANIFEST_URI` with
+the private completed manifest URI. Do not pass it as a public workflow input.
+For the normal isolated CI stack, manually select `posthog_properties_perf` in
+`scenario-dev`. It enables the isolated Trino cell and the existing Athena Pod
+Identity configuration. The properties workload is opt-in; it is not added to
+the daily selection or the existing full suite. Do not run it against an
+unrelated existing dev warehouse. The scenario's SQL setup runs once with `exec_only: true`, which drains every statement and propagates later validation errors without replaying the script. Other SQL steps default to `exec_only: false`.
+
+The generated catalog defaults to one warmup and four measured iterations per implementation. Date bounds come from the manifest as explicit UTC instants. JSON and STRUCT use the supported logical table; VARIANT runs only on PGWire.
+
+## Results and recovery
+
+The existing perf artifacts contain representation labels and the selected
+manifest's dataset version. Correctness checks precede all timed iterations and
+compare returned keys and counts against JSON. Do not report timing for a failed
+correctness gate. Engine compatibility is established by successfully reading
+the supported columns; an EXPLAIN plan alone does not establish read efficiency.
+
+If manifest, object inventory, or Athena mapping validation fails, fix the
+selection or precreated metadata and rerun preparation. Never edit the manifest,
+regenerate this fixture, or silently omit a failing engine. If a reader rejects
+the mixed Parquet schema or a property type, preserve the exact error privately
+and report the platform blocker. Keep public diagnostics free of object paths,
+customer identifiers, and raw property values.
+
+The scenario always attempts to deprovision its warehouse after execution. The
+isolated workflow also runs its normal namespace teardown. For an interrupted
+local run, follow the scenario runner recovery runbook using only the recorded
+owned warehouse identity; do not run shared-infrastructure cleanup. Preserve
+artifacts before deleting an interrupted run's resources.

--- a/docs/runbooks/properties-perf.md
+++ b/docs/runbooks/properties-perf.md
@@ -38,13 +38,16 @@ against the selected fixture, and exports its manifest-derived dataset version.
 relative paths are resolved from the repository root. `--check-env` checks
 required settings without reading S3, preparing files, or provisioning.
 
-Configure the repository Actions secret `DUCKGRES_PROPERTIES_MANIFEST_URI` with
-the private completed manifest URI. Do not pass it as a public workflow input.
-For the normal isolated CI stack, manually select `posthog_properties_perf` in
-`scenario-dev`. It enables the isolated Trino cell and the existing Athena Pod
-Identity configuration. The properties workload is opt-in; it is not added to
-the daily selection or the existing full suite. Do not run it against an
-unrelated existing dev warehouse. The scenario's SQL setup runs once with `exec_only: true`, which drains every statement and propagates later validation errors without replaying the script. Other SQL steps default to `exec_only: false`.
+Supply the private manifest URI through `DUCKGRES_SCENARIO_PROPERTIES_MANIFEST`
+in the runner environment. The harness does not create repository secrets or
+other configuration resources. GitHub workflow fixture selection remains
+unwired until its configuration source is agreed; selecting this scenario in
+Actions without that wiring fails the required-environment check.
+
+The isolated harness supports `SCENARIO_NAME=posthog_properties_perf` with
+`E2E_SUITE=trino` and the existing Athena identity configuration. The workload
+is opt-in and is not added to the daily selection or existing full suite. Do
+not run it against an unrelated existing dev warehouse. The scenario's SQL setup runs once with `exec_only: true`, which drains every statement and propagates later validation errors without replaying the script. Other SQL steps default to `exec_only: false`.
 
 The generated catalog defaults to one warmup and four measured iterations per implementation. Date bounds come from the manifest as explicit UTC instants. JSON and STRUCT use the supported logical table; VARIANT runs only on PGWire.
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.28
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.32
 	github.com/aws/aws-sdk-go-v2/service/athena v1.64.0
+	github.com/aws/aws-sdk-go-v2/service/glue v1.155.0
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.3
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.105.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/apache/thrift v0.22.0 h1:r7mTJdj51TMDe6RtcmNdQxgn9XcyfGDOzegMDRg47uc=
 github.com/apache/thrift v0.22.0/go.mod h1:1e7J/O1Ae6ZQMTYdy9xa3w9k+XHWPfRvdPyJeynQ+/g=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
 github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.45.1 h1:iIoG3NaLhV6UZpPXyPXlDj2I9oS8tV/nMcMnITCC6Ks=
@@ -48,6 +50,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 h1:3GUprIsfmGcC5SACIyB0e7E0BM1
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31/go.mod h1:7PuV1yl5e2xnUbm+RqvVg5i2iBM8EyijZNoI9wsOoOc=
 github.com/aws/aws-sdk-go-v2/service/athena v1.64.0 h1:HnHMA98zWRuaRdIYa/fvPCHeEQbJykVsXfiK74x6v2o=
 github.com/aws/aws-sdk-go-v2/service/athena v1.64.0/go.mod h1:PvOgT+mAEoXeoG7Nun4D1h8jiJ21dH3ms80DZFrw+hU=
+github.com/aws/aws-sdk-go-v2/service/glue v1.155.0 h1:7iMk8SpPMfjuTCpePjMCRKx6m3OFeSmeS6xvrIcmyAw=
+github.com/aws/aws-sdk-go-v2/service/glue v1.155.0/go.mod h1:oFFVajtCNkJGtEBuWdSA7+ZRfhWLpUaAo790bQESC98=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13 h1:mbRIur/BiHK6SKPjoBIXSE/hJ6g6JGRLuxQy1jGjlN4=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13/go.mod h1:ITg9em2KbJx1s0y4aqRX5OYWG6HBZ5TVR//OdpEZ2CQ=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.23 h1:9Fjh6fi/U5JEStVZijmaMpUwE/gvBJj7x2B/PjbO9To=

--- a/justfile
+++ b/justfile
@@ -520,3 +520,13 @@ gen-certs:
 [group('scripts')]
 seed-ducklake:
     ./scripts/seed_ducklake.sh
+
+# Validate the immutable properties fixture and prepare workload SQL/catalog.
+[group('test')]
+prepare-properties-perf manifest output_dir="/tmp/properties-perf":
+    go run ./cmd/perf-properties-prepare -manifest {{quote(manifest)}} -output-dir {{quote(output_dir)}}
+
+# Run the published properties workload in a configured disposable warehouse.
+[group('test')]
+scenario-properties-perf:
+    ./scripts/scenario_run.sh tests/mw-dev/scenario/scenarios/posthog_properties_perf.yaml

--- a/scripts/scenario_run.sh
+++ b/scripts/scenario_run.sh
@@ -130,6 +130,18 @@ if [ "$check_env_only" -eq 1 ]; then
   exit 0
 fi
 
+# Prepare only this explicitly selected workload; environment checks remain read-only.
+if [ "$(basename "$scenario_file")" = "posthog_properties_perf.yaml" ]; then
+  export DUCKGRES_SCENARIO_PROPERTIES_OUTPUT_DIR="$(root_relative_path "${DUCKGRES_SCENARIO_PROPERTIES_OUTPUT_DIR:-/tmp/properties-perf}")"
+  go run ./cmd/perf-properties-prepare \
+    -manifest "$DUCKGRES_SCENARIO_PROPERTIES_MANIFEST" \
+    -output-dir "$DUCKGRES_SCENARIO_PROPERTIES_OUTPUT_DIR" \
+    -athena-database "$DUCKGRES_SCENARIO_ATHENA_DATABASE" \
+    -athena-region "$DUCKGRES_SCENARIO_ATHENA_REGION"
+  DUCKGRES_SCENARIO_PROPERTIES_DATASET_VERSION="$(cat "$DUCKGRES_SCENARIO_PROPERTIES_OUTPUT_DIR/dataset-version.txt")"
+  export DUCKGRES_SCENARIO_PROPERTIES_DATASET_VERSION
+fi
+
 args=(
   go test -count=1 ./tests/mw-dev/scenario
   -timeout "$go_test_timeout"

--- a/tests/mw-dev/run.sh
+++ b/tests/mw-dev/run.sh
@@ -420,7 +420,7 @@ cmd_deploy() {
   ensure_pod_identity
   restart_cp_with_identity
 
-  if [ "$SCENARIO_NAME" = "posthog_frozen_perf" ]; then
+  if [ "$SCENARIO_NAME" = "posthog_frozen_perf" ] || [ "$SCENARIO_NAME" = "posthog_properties_perf" ]; then
     ensure_scenario_pod_identity
   fi
 
@@ -658,6 +658,8 @@ spec:
             - { name: DUCKGRES_SCENARIO_ATHENA_WORKGROUP, value: "${DUCKGRES_SCENARIO_ATHENA_WORKGROUP:-}" }
             - { name: DUCKGRES_SCENARIO_ATHENA_DATABASE, value: "${DUCKGRES_SCENARIO_ATHENA_DATABASE:-}" }
             - { name: DUCKGRES_SCENARIO_ATHENA_RESULTS_S3_URI, value: "${DUCKGRES_SCENARIO_ATHENA_RESULTS_S3_URI:-}" }
+            - { name: DUCKGRES_SCENARIO_PROPERTIES_MANIFEST, value: "${DUCKGRES_SCENARIO_PROPERTIES_MANIFEST:-}" }
+            - { name: DUCKGRES_SCENARIO_PROPERTIES_OUTPUT_DIR, value: "/tmp/properties-perf" }
             - { name: DUCKGRES_SCENARIO_DBT_BIN, value: "dbt" }
             - { name: DUCKGRES_K8S_WORKER_CPU_REQUEST, value: "$DUCKGRES_K8S_WORKER_CPU_REQUEST" }
             - { name: DUCKGRES_K8S_WORKER_MEMORY_REQUEST, value: "$DUCKGRES_K8S_WORKER_MEMORY_REQUEST" }

--- a/tests/mw-dev/scenario/runner_test.go
+++ b/tests/mw-dev/scenario/runner_test.go
@@ -1027,7 +1027,7 @@ func resolveScenarioFilePaths(s core.Scenario, baseDir string) core.Scenario {
 		with := make(map[string]any, len(step.With))
 		for k, v := range step.With {
 			if k == "file" || k == "catalog_file" || k == "project_dir" || k == "profiles_dir" {
-				if file, ok := v.(string); ok && file != "" && !filepath.IsAbs(file) {
+				if file, ok := v.(string); ok && file != "" && !filepath.IsAbs(file) && !strings.HasPrefix(file, "${env:") {
 					v = filepath.Clean(filepath.Join(baseDir, file))
 				}
 			}
@@ -1143,4 +1143,25 @@ func containsTemplate(value any) bool {
 		return strings.Contains(typed, "${")
 	}
 	return false
+}
+
+func TestPropertiesScenarioGeneratedPathsResolve(t *testing.T) {
+	t.Setenv("DUCKGRES_SCENARIO_PROPERTIES_OUTPUT_DIR", "/tmp/properties-generated")
+	scenario, _, err := loadScenarioForRun(filepath.Join("scenarios", "posthog_properties_perf.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, step := range scenario.Steps {
+		for _, field := range []string{"file", "catalog_file"} {
+			if path, ok := step.With[field].(string); ok {
+				resolved, err := core.ResolveEnvTemplates(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if filepath.Dir(resolved) != "/tmp/properties-generated" {
+					t.Fatalf("generated artifact path = %q", resolved)
+				}
+			}
+		}
+	}
 }

--- a/tests/mw-dev/scenario/scenarios/posthog_properties_perf.yaml
+++ b/tests/mw-dev/scenario/scenarios/posthog_properties_perf.yaml
@@ -1,0 +1,89 @@
+name: posthog-properties-perf
+run_id_prefix: scenario-properties-perf
+required_env:
+  - DUCKGRES_SCENARIO_ORG_ID
+  - DUCKGRES_SCENARIO_PROPERTIES_MANIFEST
+  - DUCKGRES_SCENARIO_TRINO_CA_CERT
+  - DUCKGRES_SCENARIO_TRINO_CATALOG_STORE_DSN
+  - DUCKGRES_SCENARIO_ATHENA_REGION
+  - DUCKGRES_SCENARIO_ATHENA_WORKGROUP
+  - DUCKGRES_SCENARIO_ATHENA_DATABASE
+  - DUCKGRES_SCENARIO_ATHENA_RESULTS_S3_URI
+  - DUCKGRES_K8S_WORKER_CPU_REQUEST
+  - DUCKGRES_K8S_WORKER_MEMORY_REQUEST
+steps:
+  - id: provision
+    type: provision_warehouse
+    with:
+      org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
+      request:
+        database_name: scenario-properties-perf-${run_id_token}
+        team_id: 1
+        metadata_store:
+          type: cnpg-shard
+        ducklake:
+          enabled: true
+        data_store:
+          type: s3bucket
+        trino:
+          enabled: true
+          tier: free
+
+  - id: wait_ready
+    type: wait_warehouse_ready
+    with:
+      org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
+      timeout: 15m
+      poll_interval: 10s
+
+  - id: wait_trino_ready
+    type: wait_trino_ready
+    depends_on: [wait_ready]
+    with:
+      org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
+      timeout: 15m
+      poll_interval: 10s
+
+  - id: setup_properties
+    type: sql
+    depends_on: [wait_ready]
+    with:
+      org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
+      catalog: ducklake
+      file: ${env:DUCKGRES_SCENARIO_PROPERTIES_OUTPUT_DIR}/setup.sql
+      max_attempts: 1
+      exec_only: true
+
+  - id: perf_queries
+    type: perf_queries
+    depends_on: [setup_properties, wait_trino_ready]
+    with:
+      org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
+      catalog: ducklake
+      catalog_file: ${env:DUCKGRES_SCENARIO_PROPERTIES_OUTPUT_DIR}/catalog.yaml
+      targets: [pgwire_uncached, pgwire_cached, trino, athena]
+      trino_ca_cert_file: ${env:DUCKGRES_SCENARIO_TRINO_CA_CERT}
+      trino_startup_timeout: 2m
+      trino_startup_poll_interval: 2s
+      athena_region: ${env:DUCKGRES_SCENARIO_ATHENA_REGION}
+      athena_workgroup: ${env:DUCKGRES_SCENARIO_ATHENA_WORKGROUP}
+      athena_catalog: AwsDataCatalog
+      athena_database: ${env:DUCKGRES_SCENARIO_ATHENA_DATABASE}
+      athena_output_location: ${env:DUCKGRES_SCENARIO_ATHENA_RESULTS_S3_URI}
+      athena_poll_interval: 500ms
+      athena_query_timeout: 30m
+      run_id: ${run_id}
+      dataset_version: ${env:DUCKGRES_SCENARIO_PROPERTIES_DATASET_VERSION}
+      fail_on_query_errors: true
+      worker_cpu: ${env:DUCKGRES_K8S_WORKER_CPU_REQUEST}
+      worker_memory: ${env:DUCKGRES_K8S_WORKER_MEMORY_REQUEST}
+
+  - id: deprovision
+    type: deprovision_warehouse
+    depends_on: [perf_queries]
+    always_run: true
+    with:
+      org_id: ${env:DUCKGRES_SCENARIO_ORG_ID}
+      verify_deleted: true
+      cleanup_timeout: 15m
+      poll_interval: 10s

--- a/tests/mw-dev/scenario/script_test.go
+++ b/tests/mw-dev/scenario/script_test.go
@@ -74,10 +74,12 @@ func TestDevScenarioWorkflowUsesUnifiedMwDevHarness(t *testing.T) {
 		t.Fatalf("read dev scenario workflow: %v", err)
 	}
 	workflow := string(raw)
+	if strings.Contains(workflow, "secrets.DUCKGRES_PROPERTIES_MANIFEST_URI") {
+		t.Fatal("properties fixture selection must not require a new repository secret")
+	}
 
 	for _, required := range []string{
 		"name: scenario-dev",
-		"DUCKGRES_SCENARIO_PROPERTIES_MANIFEST: ${{ secrets.DUCKGRES_PROPERTIES_MANIFEST_URI }}",
 		"workflow_dispatch:",
 		"scenario:",
 		"default: full-suite",

--- a/tests/mw-dev/scenario/script_test.go
+++ b/tests/mw-dev/scenario/script_test.go
@@ -77,6 +77,7 @@ func TestDevScenarioWorkflowUsesUnifiedMwDevHarness(t *testing.T) {
 
 	for _, required := range []string{
 		"name: scenario-dev",
+		"DUCKGRES_SCENARIO_PROPERTIES_MANIFEST: ${{ secrets.DUCKGRES_PROPERTIES_MANIFEST_URI }}",
 		"workflow_dispatch:",
 		"scenario:",
 		"default: full-suite",
@@ -105,7 +106,7 @@ func TestDevScenarioWorkflowUsesUnifiedMwDevHarness(t *testing.T) {
 		"if: env.SCENARIO_NAME == 'posthog_frozen_perf'",
 		"bash scripts/scenario_athena_config.sh >> \"$GITHUB_ENV\"",
 		"TRINO_IMAGE: ghcr.io/posthog/trino:",
-		"E2E_SUITE: ${{ (matrix.scenario == 'posthog_frozen_perf' || matrix.scenario == 'posthog_frozen_perf_trino_cached') && 'trino' || 'neutral' }}",
+		"E2E_SUITE: ${{ (matrix.scenario == 'posthog_frozen_perf' || matrix.scenario == 'posthog_frozen_perf_trino_cached' || matrix.scenario == 'posthog_properties_perf') && 'trino' || 'neutral' }}",
 		"DUCKGRES_K8S_WORKER_CPU_REQUEST: \"3\"",
 		"DUCKGRES_K8S_WORKER_MEMORY_REQUEST: 12Gi",
 		"role-duration-seconds: 16200",
@@ -138,6 +139,7 @@ func TestDevScenarioWorkflowUsesUnifiedMwDevHarness(t *testing.T) {
 		"MW_DEV_ATHENA_RESULTS_S3_URI",
 		"skip_slow:",
 		"inputs.skip_slow",
+		"inputs.properties_manifest",
 		"scenario-skipped:",
 		"test-scenario-full",
 		"use_shared_dev:",
@@ -249,5 +251,44 @@ func TestScenarioWorkflowsUseNode24Actions(t *testing.T) {
 		if !strings.Contains(string(imageWorkflow), required) {
 			t.Fatalf("image workflow missing Node 24 action pin %q", required)
 		}
+	}
+}
+
+func TestPropertiesScenarioPreparation(t *testing.T) {
+	script := filepath.Join("..", "..", "..", "scripts", "scenario_run.sh")
+	dir := t.TempDir()
+	log := filepath.Join(dir, "calls")
+	mock := "#!/bin/sh\nif [ \"$1\" = run ]; then printf 'properties-fixture-test\\n' > \"$DUCKGRES_SCENARIO_PROPERTIES_OUTPUT_DIR/dataset-version.txt\"; fi\nprintf '%s\\n' \"$*\" >> \"$CALL_LOG\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "go"), []byte(mock), 0755); err != nil {
+		t.Fatal(err)
+	}
+	env := []string{"PATH=" + dir + ":" + os.Getenv("PATH"), "CALL_LOG=" + log}
+	for _, name := range []string{"API_BASE", "INTERNAL_SECRET", "PG_HOST", "SNI_SUFFIX", "ORG_ID", "TRINO_CA_CERT", "TRINO_CATALOG_STORE_DSN", "ATHENA_REGION", "ATHENA_WORKGROUP", "ATHENA_DATABASE", "ATHENA_RESULTS_S3_URI"} {
+		env = append(env, "DUCKGRES_SCENARIO_"+name+"=synthetic")
+	}
+	env = append(env, "DUCKGRES_K8S_WORKER_CPU_REQUEST=1", "DUCKGRES_K8S_WORKER_MEMORY_REQUEST=1Gi", "DUCKGRES_SCENARIO_PROPERTIES_MANIFEST=s3://fixture/complete.json", "DUCKGRES_SCENARIO_PROPERTIES_OUTPUT_DIR="+dir)
+	for _, check := range []bool{true, false} {
+		args := []string{script, "tests/mw-dev/scenario/scenarios/posthog_properties_perf.yaml"}
+		if check {
+			args = append(args, "--check-env")
+		}
+		cmd := exec.Command("bash", args...)
+		cmd.Env = env
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("script: %v: %s", err, out)
+		}
+		if check {
+			if _, err := os.Stat(log); !os.IsNotExist(err) {
+				t.Fatal("check-env must not prepare or run")
+			}
+		}
+	}
+	calls, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(calls)), "\n")
+	if len(lines) != 2 || !strings.HasPrefix(lines[0], "run ./cmd/perf-properties-prepare -manifest s3://fixture/complete.json -output-dir "+dir) || !strings.HasPrefix(lines[1], "test ") {
+		t.Fatalf("wrong preparation/run ordering: %s", calls)
 	}
 }

--- a/tests/mw-dev/scenario/sql/driver.go
+++ b/tests/mw-dev/scenario/sql/driver.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	"context"
+	stdsql "database/sql"
 	"fmt"
 	"time"
 )
@@ -11,12 +12,14 @@ type Driver interface {
 }
 
 type QueryRequest struct {
-	StepID  string
-	QueryID string
-	OrgID   string
-	Catalog string
-	SQL     string
-	PGWire  PGWireConnection
+	// ExecOnly consumes all statements and never retries a mutating script as a query.
+	ExecOnly bool
+	StepID   string
+	QueryID  string
+	OrgID    string
+	Catalog  string
+	SQL      string
+	PGWire   PGWireConnection
 }
 
 type QueryResult struct {
@@ -24,7 +27,9 @@ type QueryResult struct {
 	Duration time.Duration
 }
 
-type DatabaseDriver struct{}
+type DatabaseDriver struct {
+	openDB func(PGWireConnection) (*stdsql.DB, error)
+}
 
 func NewDatabaseDriver() *DatabaseDriver {
 	return &DatabaseDriver{}
@@ -32,7 +37,11 @@ func NewDatabaseDriver() *DatabaseDriver {
 
 func (d *DatabaseDriver) Execute(ctx context.Context, req QueryRequest) (QueryResult, error) {
 	started := time.Now()
-	db, err := req.PGWire.OpenDB()
+	openDB := d.openDB
+	if openDB == nil {
+		openDB = PGWireConnection.OpenDB
+	}
+	db, err := openDB(req.PGWire)
 	if err != nil {
 		return QueryResult{}, fmt.Errorf("open pgwire connection: %w", err)
 	}
@@ -40,6 +49,14 @@ func (d *DatabaseDriver) Execute(ctx context.Context, req QueryRequest) (QueryRe
 		_ = db.Close()
 	}()
 
+	if req.ExecOnly {
+		res, err := db.ExecContext(ctx, req.SQL)
+		if err != nil {
+			return QueryResult{}, err
+		}
+		affected, _ := res.RowsAffected()
+		return QueryResult{Rows: affected, Duration: time.Since(started)}, nil
+	}
 	rows, err := db.QueryContext(ctx, req.SQL)
 	if err == nil {
 		defer func() {

--- a/tests/mw-dev/scenario/sql/driver_test.go
+++ b/tests/mw-dev/scenario/sql/driver_test.go
@@ -1,0 +1,54 @@
+package sql
+
+import (
+	"context"
+	stdsql "database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/posthog/duckgres/tests/mw-dev/scenario/core"
+)
+
+func TestExecOnlyPropagatesLateErrorWithoutReplay(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "setup.duckdb")
+	db, err := stdsql.Open("duckdb", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("CREATE TABLE attempts (n INTEGER)"); err != nil {
+		t.Fatal(err)
+	}
+	d := &DatabaseDriver{openDB: func(PGWireConnection) (*stdsql.DB, error) { return db, nil }}
+	_, err = d.Execute(context.Background(), QueryRequest{ExecOnly: true, SQL: "INSERT INTO attempts VALUES (1); SELECT 1; SELECT error('late validation failure');"})
+	if err == nil || !strings.Contains(err.Error(), "late validation failure") {
+		t.Fatalf("late error swallowed: %v", err)
+	}
+	verify, err := stdsql.Open("duckdb", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = verify.Close() })
+	var attempts int
+	if err := verify.QueryRow("SELECT count(*) FROM attempts").Scan(&attempts); err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 1 {
+		t.Fatalf("script replayed: attempts=%d", attempts)
+	}
+}
+
+func TestSQLStepPassesExecOnlyExplicitly(t *testing.T) {
+	for _, execOnly := range []bool{false, true} {
+		var captured QueryRequest
+		e := NewExecutor(ExecutorConfig{Connection: ConnectionConfig{DialHost: "127.0.0.1", SNISuffix: ".example", SSLMode: "disable"}, Driver: &fakeDriver{executeFunc: func(_ context.Context, q QueryRequest) (QueryResult, error) { captured = q; return QueryResult{}, nil }}})
+		step := core.Step{ID: "setup", Type: StepTypeSQL, With: map[string]any{"org_id": "example-org", "password": "example", "sql": "SELECT 1", "exec_only": execOnly}}
+		if err := e.ExecuteStep(context.Background(), step); err != nil {
+			t.Fatal(err)
+		}
+		if captured.ExecOnly != execOnly {
+			t.Fatalf("ExecOnly=%v want %v", captured.ExecOnly, execOnly)
+		}
+	}
+}

--- a/tests/mw-dev/scenario/sql/steps.go
+++ b/tests/mw-dev/scenario/sql/steps.go
@@ -220,13 +220,22 @@ func (e *Executor) queryRequest(step core.Step, spec querySpec, resultID string)
 	if err != nil {
 		return QueryRequest{}, err
 	}
+	execOnly := false
+	if value, ok := step.With["exec_only"]; ok {
+		var valid bool
+		execOnly, valid = value.(bool)
+		if !valid {
+			return QueryRequest{}, invalidStep(step.ID, "exec_only must be a boolean")
+		}
+	}
 	return QueryRequest{
-		StepID:  resultID,
-		QueryID: spec.ID,
-		OrgID:   orgID,
-		Catalog: spec.Catalog,
-		SQL:     spec.SQL,
-		PGWire:  connection,
+		ExecOnly: execOnly,
+		StepID:   resultID,
+		QueryID:  spec.ID,
+		OrgID:    orgID,
+		Catalog:  spec.Catalog,
+		SQL:      spec.SQL,
+		PGWire:   connection,
 	}, nil
 }
 

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -186,9 +186,9 @@ Artifacts are written to `artifacts/perf/<run_id>`:
 - `runner.log`
 - `dataset_manifest.json` (only when `DUCKGRES_PERF_DATASET_VERSION` is set)
 
-## Artifact Schema Contract (v1)
+## Artifact Schema Contract (v2)
 
-`query_results.csv` is the canonical per-query artifact and its columns are fixed in v1:
+`query_results.csv` is the canonical per-query artifact and its columns are:
 
 - `query_id`
 - `intent_id`
@@ -200,16 +200,16 @@ Artifacts are written to `artifacts/perf/<run_id>`:
 - `rows`
 - `duration_ms`
 - `started_at`
+- `representation` (empty for existing workloads; `json`, `struct`, or `variant` for properties)
 
 `measure_iteration` is the 1-based measured repetition within a run (`0` is reserved for non-measured warmup work and is not emitted to the CSV today).
 `duration_ms` is emitted as milliseconds with fixed precision, and `started_at` is UTC RFC3339Nano.
-No CSV schema mutation is expected in this phase.
+The publisher accepts both the original ten-column v1 header and the v2 header with the appended representation column.
 
 `query_service_metrics.csv` is an additive sidecar. Provider-backed rows record
 queue, planning, engine, and service time; bytes scanned; DPU count when the
 service returns it; result reuse; and engine version. `query_results.csv`
-remains the canonical latency/status artifact and keeps its v1 header
-unchanged.
+remains the canonical latency/status artifact. Both CSVs append the representation label; stable query IDs also include it.
 
 ## Nightly Run
 
@@ -271,3 +271,19 @@ protocol labels in performance comparisons.
 
 Trino `physicalInputBytes` can include bytes served from cache. Use cache-manager
 external-read/hit counters to distinguish storage traffic from cached reads.
+
+## Published properties workload
+
+`just scenario-properties-perf` runs the opt-in JSON/STRUCT/VARIANT comparison
+on a validated completion manifest. Set `DUCKGRES_SCENARIO_PROPERTIES_MANIFEST`
+explicitly; there is no default fixture. Preparation defaults to
+`/tmp/properties-perf` and a five-minute timeout. The catalog uses one warmup
+and four measured iterations, with UTC date bounds from the manifest. JSON and
+STRUCT run on PGWire, Trino, and Athena; VARIANT runs on PGWire only.
+
+`just prepare-properties-perf "$DUCKGRES_SCENARIO_PROPERTIES_MANIFEST"` emits
+private setup inputs after validating the manifest and live object inventory.
+The optional second argument changes the output directory. The scenario also
+verifies the precreated Athena table before provisioning, then compares complete
+query results outside timing. See the [properties runbook](../../docs/runbooks/properties-perf.md)
+for isolated execution, metadata registration, configuration, and recovery.

--- a/tests/perf/core/catalog.go
+++ b/tests/perf/core/catalog.go
@@ -417,6 +417,23 @@ func validateCatalog(c Catalog) error {
 		if q.PGWireSQL == "" {
 			return fmt.Errorf("query %s missing pgwire_sql", q.QueryID)
 		}
+		if q.Representation != "" && q.Representation != "json" && q.Representation != "struct" && q.Representation != "variant" {
+			return fmt.Errorf("query %s has unsupported representation %q", q.QueryID, q.Representation)
+		}
+		queryTargets := q.Targets
+		if len(queryTargets) == 0 {
+			queryTargets = c.Targets
+		}
+		seenQueryTargets := map[Protocol]bool{}
+		for _, target := range queryTargets {
+			if _, ok := seenTargets[target]; !ok || seenQueryTargets[target] {
+				return fmt.Errorf("query %s has invalid or duplicate target %q", q.QueryID, target)
+			}
+			seenQueryTargets[target] = true
+			if q.Representation == "variant" && target != ProtocolPGWire && target != ProtocolPGWireUncached && target != ProtocolPGWireCached {
+				return fmt.Errorf("query %s variant requires a supported PGWire reader", q.QueryID)
+			}
+		}
 		if q.StorageTarget != "" {
 			hasPairedQueries = true
 		}

--- a/tests/perf/core/correctness.go
+++ b/tests/perf/core/correctness.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"reflect"
+)
+
+// ResultReader collects complete result values only for the untimed correctness
+// gate. Nil cells retain SQL NULL, distinct from empty strings and literal null.
+type ResultReader interface {
+	ReadResults(context.Context, Query, []any) ([][]*string, error)
+}
+
+func (r *QueryRunner) validateRepresentations(ctx context.Context) error {
+	baselines := map[string][][]*string{}
+	// Read every JSON baseline first, including each engine/storage implementation.
+	for _, representation := range []string{"json", "other"} {
+		for _, protocol := range r.cfg.Catalog.Targets {
+			for _, q := range r.cfg.Catalog.Queries {
+				if q.Representation == "" || !querySupportsProtocol(q, protocol) || (q.Representation == "json") != (representation == "json") {
+					continue
+				}
+				reader, ok := r.cfg.Drivers[protocol].(ResultReader)
+				if !ok {
+					return fmt.Errorf("correctness gate: %s driver cannot read result values", protocol)
+				}
+				expected, exists := baselines[q.IntentID]
+				if representation != "json" && !exists {
+					return fmt.Errorf("correctness gate: intent %s has no JSON baseline", q.IntentID)
+				}
+				actual, err := reader.ReadResults(ctx, q, orderedParamValues(q.Params))
+				if err != nil {
+					return fmt.Errorf("correctness gate (%s/%s): %w", protocol, q.QueryID, err)
+				}
+				// Avoid including raw result values in diagnostics or public artifacts.
+				if exists && !reflect.DeepEqual(expected, actual) {
+					return fmt.Errorf("correctness gate (%s/%s): complete ordered results differ from JSON baseline for intent %s", protocol, q.QueryID, q.IntentID)
+				}
+				if !exists {
+					baselines[q.IntentID] = actual
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// ReadSQLResults normalizes driver string/byte/integer representations through
+// database/sql conversion without conflating SQL NULL with textual values.
+func ReadSQLResults(rows *sql.Rows) ([][]*string, error) {
+	defer func() { _ = rows.Close() }()
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	results := make([][]*string, 0)
+	for rows.Next() {
+		values := make([]sql.NullString, len(columns))
+		pointers := make([]any, len(columns))
+		for i := range values {
+			pointers[i] = &values[i]
+		}
+		if err := rows.Scan(pointers...); err != nil {
+			return nil, err
+		}
+		row := make([]*string, len(values))
+		for i, value := range values {
+			if value.Valid {
+				s := value.String
+				row[i] = &s
+			}
+		}
+		results = append(results, row)
+	}
+	return results, rows.Err()
+}

--- a/tests/perf/core/correctness_test.go
+++ b/tests/perf/core/correctness_test.go
@@ -1,0 +1,90 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type resultDriver struct {
+	protocol Protocol
+	results  map[string][][]*string
+	events   *[]string
+	readErr  error
+}
+
+func (d *resultDriver) Protocol() Protocol { return d.protocol }
+func (d *resultDriver) Close() error       { return nil }
+func (d *resultDriver) Execute(_ context.Context, q Query, _ []any) (ExecutionResult, error) {
+	*d.events = append(*d.events, "time:"+q.QueryID)
+	return ExecutionResult{Rows: 1}, nil
+}
+func (d *resultDriver) ReadResults(_ context.Context, q Query, _ []any) ([][]*string, error) {
+	*d.events = append(*d.events, "read:"+q.QueryID)
+	return d.results[q.QueryID], d.readErr
+}
+func cell(s string) *string { return &s }
+func TestCorrectnessGateBeforeAnyTiming(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		value    *string
+		err      error
+		wantFail bool
+	}{
+		{"equal", cell("Chrome"), nil, false}, {"different key", cell("chrome"), nil, true}, {"SQL null", nil, nil, true}, {"read failure", nil, errors.New("reader failed"), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var events []string
+			queries := []Query{{QueryID: "json", IntentID: "browser", Representation: "json"}, {QueryID: "struct", IntentID: "browser", Representation: "struct"}}
+			d := &resultDriver{protocol: ProtocolPGWire, events: &events, results: map[string][][]*string{"json": {{cell("Chrome"), cell("10")}}, "struct": {{tc.value, cell("10")}}}, readErr: tc.err}
+			r := NewQueryRunner(RunnerConfig{Catalog: Catalog{Targets: []Protocol{ProtocolPGWire}, Queries: queries, WarmupIterations: 1, MeasureIterations: 1}, Drivers: map[Protocol]ProtocolDriver{ProtocolPGWire: d}})
+			_, err := r.Run(context.Background())
+			if (err != nil) != tc.wantFail {
+				t.Fatalf("error=%v", err)
+			}
+			if tc.wantFail {
+				for _, e := range events {
+					if strings.HasPrefix(e, "time:") {
+						t.Fatalf("timing after failed gate: %v", events)
+					}
+				}
+			} else if len(events) != 6 || events[0] != "read:json" || events[1] != "read:struct" {
+				t.Fatalf("events %v", events)
+			}
+		})
+	}
+}
+func TestCorrectnessGateComparesCountsAndEngines(t *testing.T) {
+	var events []string
+	q := Query{QueryID: "json", IntentID: "browser", Representation: "json"}
+	a := &resultDriver{protocol: ProtocolPGWire, events: &events, results: map[string][][]*string{"json": {{cell("null"), cell("2")}}}}
+	b := &resultDriver{protocol: ProtocolTrino, events: &events, results: map[string][][]*string{"json": {{cell("null"), cell("3")}}}}
+	_, err := NewQueryRunner(RunnerConfig{Catalog: Catalog{Targets: []Protocol{ProtocolPGWire, ProtocolTrino}, Queries: []Query{q}, MeasureIterations: 1}, Drivers: map[Protocol]ProtocolDriver{ProtocolPGWire: a, ProtocolTrino: b}}).Run(context.Background())
+	if err == nil {
+		t.Fatal("same row count with different aggregate counts passed")
+	}
+	for _, e := range events {
+		if strings.HasPrefix(e, "time:") {
+			t.Fatal(events)
+		}
+	}
+}
+func TestCorrectnessRequiresJSONBaseline(t *testing.T) {
+	var events []string
+	d := &resultDriver{events: &events}
+	_, err := NewQueryRunner(RunnerConfig{Catalog: Catalog{Targets: []Protocol{ProtocolPGWire}, Queries: []Query{{QueryID: "struct", IntentID: "browser", Representation: "struct"}}}, Drivers: map[Protocol]ProtocolDriver{ProtocolPGWire: d}}).Run(context.Background())
+	if err == nil {
+		t.Fatal("missing JSON baseline accepted")
+	}
+}
+func TestRepresentationDialectAndRouting(t *testing.T) {
+	q := Query{Representation: "json", PGWireSQL: "SELECT json_extract_string(properties, '$.\"$browser\"')", Targets: []Protocol{ProtocolPGWire}}
+	sql, err := q.SQLFor(ProtocolTrino)
+	if err != nil || !strings.Contains(sql, "json_extract_scalar") {
+		t.Fatalf("sql=%q error=%v", sql, err)
+	}
+	if querySupportsProtocol(q, ProtocolTrino) || !querySupportsProtocol(q, ProtocolPGWire) {
+		t.Fatal("query targets ignored")
+	}
+}

--- a/tests/perf/core/properties_catalog_test.go
+++ b/tests/perf/core/properties_catalog_test.go
@@ -1,0 +1,17 @@
+package core
+
+import "testing"
+
+func TestRepresentationCatalogRejectsInvalidRouting(t *testing.T) {
+	for _, fields := range []string{
+		"representation: typo",
+		"representation: variant\n    targets: [trino]",
+		"representation: struct\n    targets: [unknown]",
+		"representation: struct\n    targets: [pgwire, pgwire]",
+	} {
+		raw := "name: properties\ndataset_scale: 1\nmeasure_iterations: 1\ntargets: [pgwire, trino]\nqueries:\n  - query_id: browser\n    intent_id: browser\n    pgwire_sql: SELECT 1\n    " + fields + "\n"
+		if _, err := ParseCatalog([]byte(raw)); err == nil {
+			t.Errorf("accepted invalid routing: %s", fields)
+		}
+	}
+}

--- a/tests/perf/core/runner.go
+++ b/tests/perf/core/runner.go
@@ -78,6 +78,10 @@ func (r *QueryRunner) Run(ctx context.Context) (RunSummary, error) {
 		}
 	}
 
+	if err := r.validateRepresentations(ctx); err != nil {
+		return summary, err
+	}
+
 	for _, protocol := range r.cfg.Catalog.Targets {
 		warmupIterations := r.cfg.Catalog.WarmupIterations
 		for i := 0; i < warmupIterations; i++ {
@@ -120,6 +124,7 @@ func (r *QueryRunner) executeIteration(ctx context.Context, protocol Protocol, m
 		started := r.cfg.Now()
 		result := QueryResult{
 			QueryID:          query.QueryID,
+			Representation:   query.Representation,
 			IntentID:         query.IntentID,
 			MeasureIteration: measureIteration,
 			Protocol:         protocol,
@@ -164,6 +169,18 @@ func (r *QueryRunner) executeIteration(ctx context.Context, protocol Protocol, m
 // table, Trino measures the shared DuckLake table, and Athena measures its
 // Glue external table over the same immutable Parquet files.
 func querySupportsProtocol(query Query, protocol Protocol) bool {
+	if len(query.Targets) > 0 {
+		allowed := false
+		for _, target := range query.Targets {
+			if target == protocol {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return false
+		}
+	}
 	switch query.StorageTarget {
 	case "":
 		return true

--- a/tests/perf/core/sink.go
+++ b/tests/perf/core/sink.go
@@ -40,6 +40,7 @@ func NewArtifactSink(dir string) (*ArtifactSink, error) {
 		"rows",
 		"duration_ms",
 		"started_at",
+		"representation",
 	}
 	if err := w.Write(header); err != nil {
 		_ = f.Close()
@@ -70,6 +71,7 @@ func NewArtifactSink(dir string) (*ArtifactSink, error) {
 		"dpu_count",
 		"result_reused",
 		"engine_version",
+		"representation",
 	}
 	if err := serviceMetricsWriter.Write(serviceMetricsHeader); err != nil {
 		_ = serviceMetricsFile.Close()
@@ -106,6 +108,7 @@ func (s *ArtifactSink) Record(result QueryResult) error {
 		strconv.FormatInt(result.Rows, 10),
 		strconv.FormatFloat(float64(result.Duration)/float64(time.Millisecond), 'f', 6, 64),
 		result.StartedAt.UTC().Format(time.RFC3339Nano),
+		result.Representation,
 	}
 	if err := s.csvWriter.Write(row); err != nil {
 		return fmt.Errorf("write csv row: %w", err)
@@ -129,6 +132,7 @@ func (s *ArtifactSink) Record(result QueryResult) error {
 			strconv.FormatFloat(metrics.DPUCount, 'f', -1, 64),
 			strconv.FormatBool(metrics.ResultReused),
 			metrics.EngineVersion,
+			result.Representation,
 		}
 		if err := s.serviceMetricsWriter.Write(serviceMetricsRow); err != nil {
 			return fmt.Errorf("write service metrics row: %w", err)

--- a/tests/perf/core/sink_test.go
+++ b/tests/perf/core/sink_test.go
@@ -134,7 +134,7 @@ paired_queries:
 	if err != nil {
 		t.Fatalf("read query_results.csv: %v", err)
 	}
-	wantHeader := []string{"query_id", "intent_id", "measure_iteration", "protocol", "status", "error", "error_class", "rows", "duration_ms", "started_at"}
+	wantHeader := []string{"query_id", "intent_id", "measure_iteration", "protocol", "status", "error", "error_class", "rows", "duration_ms", "started_at", "representation"}
 	if !reflect.DeepEqual(records[0], wantHeader) {
 		t.Fatalf("CSV header: got %v want %v", records[0], wantHeader)
 	}
@@ -143,7 +143,7 @@ paired_queries:
 	}
 }
 
-func TestArtifactSinkWritesAthenaServiceMetricsWithoutChangingQueryResultsV1(t *testing.T) {
+func TestArtifactSinkWritesAthenaServiceMetrics(t *testing.T) {
 	dir := t.TempDir()
 	sink, err := NewArtifactSink(dir)
 	if err != nil {
@@ -184,9 +184,9 @@ func TestArtifactSinkWritesAthenaServiceMetricsWithoutChangingQueryResultsV1(t *
 	if err != nil {
 		t.Fatalf("read query_results.csv: %v", err)
 	}
-	wantQueryHeader := []string{"query_id", "intent_id", "measure_iteration", "protocol", "status", "error", "error_class", "rows", "duration_ms", "started_at"}
+	wantQueryHeader := []string{"query_id", "intent_id", "measure_iteration", "protocol", "status", "error", "error_class", "rows", "duration_ms", "started_at", "representation"}
 	if !reflect.DeepEqual(queryRecords[0], wantQueryHeader) {
-		t.Fatalf("query_results.csv v1 header changed: got %v want %v", queryRecords[0], wantQueryHeader)
+		t.Fatalf("query_results.csv header: got %v want %v", queryRecords[0], wantQueryHeader)
 	}
 
 	metricsFile, err := os.Open(filepath.Join(dir, "query_service_metrics.csv"))
@@ -198,11 +198,39 @@ func TestArtifactSinkWritesAthenaServiceMetricsWithoutChangingQueryResultsV1(t *
 	if err != nil {
 		t.Fatalf("read query_service_metrics.csv: %v", err)
 	}
-	wantMetricsHeader := []string{"query_id", "intent_id", "measure_iteration", "protocol", "queue_ms", "planning_ms", "engine_ms", "service_ms", "bytes_scanned", "dpu_count", "result_reused", "engine_version"}
+	wantMetricsHeader := []string{"query_id", "intent_id", "measure_iteration", "protocol", "queue_ms", "planning_ms", "engine_ms", "service_ms", "bytes_scanned", "dpu_count", "result_reused", "engine_version", "representation"}
 	if !reflect.DeepEqual(metricsRecords[0], wantMetricsHeader) {
 		t.Fatalf("service metrics header: got %v want %v", metricsRecords[0], wantMetricsHeader)
 	}
-	if got, want := metricsRecords[1], []string{"q1__athena_external", "i1", "1", "athena", "100.000000", "200.000000", "2000.000000", "2500.000000", "4096", "4", "false", "Athena engine version 3"}; !reflect.DeepEqual(got, want) {
+	if got, want := metricsRecords[1], []string{"q1__athena_external", "i1", "1", "athena", "100.000000", "200.000000", "2000.000000", "2500.000000", "4096", "4", "false", "Athena engine version 3", ""}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("service metrics row: got %v want %v", got, want)
+	}
+}
+
+func TestArtifactSinkLabelsRepresentations(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := NewArtifactSink(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = sink.Record(QueryResult{QueryID: "properties_browser_v1__struct", IntentID: "browser", Representation: "struct", ServiceMetrics: &ServiceMetrics{BytesScanned: 42}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = sink.Close(RunSummary{}, ""); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"query_results.csv", "query_service_metrics.csv"} {
+		raw, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows, err := csv.NewReader(strings.NewReader(string(raw))).ReadAll()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rows[0][len(rows[0])-1] != "representation" || rows[1][len(rows[1])-1] != "struct" {
+			t.Errorf("%s lacks representation label", name)
+		}
 	}
 }

--- a/tests/perf/core/types.go
+++ b/tests/perf/core/types.go
@@ -1,6 +1,9 @@
 package core
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 type Protocol string
 
@@ -36,12 +39,14 @@ type Catalog struct {
 }
 
 type Query struct {
-	QueryID       string         `yaml:"query_id"`
-	IntentID      string         `yaml:"intent_id"`
-	Tags          []string       `yaml:"tags"`
-	Params        map[string]any `yaml:"params"`
-	PGWireSQL     string         `yaml:"pgwire_sql"`
-	StorageTarget StorageTarget  `yaml:"-" json:"-"`
+	Representation string         `yaml:"representation,omitempty" json:"representation,omitempty"`
+	Targets        []Protocol     `yaml:"targets,omitempty" json:"-"`
+	QueryID        string         `yaml:"query_id"`
+	IntentID       string         `yaml:"intent_id"`
+	Tags           []string       `yaml:"tags"`
+	Params         map[string]any `yaml:"params"`
+	PGWireSQL      string         `yaml:"pgwire_sql"`
+	StorageTarget  StorageTarget  `yaml:"-" json:"-"`
 }
 
 // CanonicalSQL returns the single rendered SQL statement shared by protocol
@@ -73,6 +78,7 @@ type ServiceMetrics struct {
 }
 
 type QueryResult struct {
+	Representation   string          `json:"representation,omitempty"`
 	QueryID          string          `json:"query_id"`
 	IntentID         string          `json:"intent_id"`
 	MeasureIteration int             `json:"measure_iteration"`
@@ -94,4 +100,18 @@ type RunSummary struct {
 	TotalQueries   int       `json:"total_queries"`
 	TotalErrors    int       `json:"total_errors"`
 	WarmupQueries  int       `json:"warmup_queries"`
+}
+
+// SQLFor preserves canonical SQL except for the JSON scalar extractor in the
+// explicitly labeled properties workload. Its paths and semantics stay shared.
+func (q Query) SQLFor(protocol Protocol) (string, error) {
+	sql := q.CanonicalSQL()
+	if q.Representation != "" && (protocol == ProtocolTrino || protocol == ProtocolTrinoCached || protocol == ProtocolAthena) {
+		sql = strings.ReplaceAll(sql, "json_extract_string(", "json_extract_scalar(")
+	}
+	if q.Representation != "" && protocol == ProtocolAthena {
+		// Athena uses the run-specific Glue database, with a flat external table.
+		sql = strings.ReplaceAll(sql, `"properties_perf"."events_supported"`, `"properties_events_supported"`)
+	}
+	return sql, nil
 }

--- a/tests/perf/drivers/athena/driver.go
+++ b/tests/perf/drivers/athena/driver.go
@@ -84,9 +84,29 @@ func newWithClient(client athenaAPI, cfg ConnectionConfig) (*Driver, error) {
 
 func (d *Driver) Protocol() perfcore.Protocol { return perfcore.ProtocolAthena }
 
-func (d *Driver) Execute(ctx context.Context, query perfcore.Query, args []any) (result perfcore.ExecutionResult, err error) {
+func (d *Driver) Execute(ctx context.Context, query perfcore.Query, args []any) (perfcore.ExecutionResult, error) {
+	return d.execute(ctx, query, args, nil)
+}
+
+func (d *Driver) ReadResults(ctx context.Context, query perfcore.Query, args []any) ([][]*string, error) {
+	values := make([][]*string, 0)
+	_, err := d.execute(ctx, query, args, func(row athenatypes.Row) {
+		cells := make([]*string, len(row.Data))
+		for i, datum := range row.Data {
+			cells[i] = datum.VarCharValue
+		}
+		values = append(values, cells)
+	})
+	return values, err
+}
+
+func (d *Driver) execute(ctx context.Context, query perfcore.Query, args []any, collect func(athenatypes.Row)) (result perfcore.ExecutionResult, err error) {
 	if len(args) > 0 {
 		return result, fmt.Errorf("athena perf queries do not support positional parameters")
+	}
+	sqlText, err := query.SQLFor(d.Protocol())
+	if err != nil {
+		return result, err
 	}
 	queryCtx, cancel := context.WithTimeout(ctx, d.cfg.QueryTimeout)
 	defer cancel()
@@ -94,7 +114,7 @@ func (d *Driver) Execute(ctx context.Context, query perfcore.Query, args []any) 
 	startedAt := d.now()
 	defer func() { result.Duration = d.now().Sub(startedAt) }()
 	started, err := d.client.StartQueryExecution(queryCtx, &awsathena.StartQueryExecutionInput{
-		QueryString: aws.String(query.CanonicalSQL()),
+		QueryString: aws.String(sqlText),
 		WorkGroup:   aws.String(d.cfg.WorkGroup),
 		QueryExecutionContext: &athenatypes.QueryExecutionContext{
 			Catalog: aws.String(d.cfg.Catalog), Database: aws.String(d.cfg.Database),
@@ -161,7 +181,7 @@ queryComplete:
 		return result, fmt.Errorf("athena query output %q is outside configured output location %q", outputLocation, d.cfg.OutputLocation)
 	}
 
-	rows, err := d.countRows(queryCtx, *queryID)
+	rows, err := d.readRows(queryCtx, *queryID, collect)
 	if err != nil {
 		return result, err
 	}
@@ -191,7 +211,7 @@ func serviceMetrics(execution *athenatypes.QueryExecution) *perfcore.ServiceMetr
 	return metrics
 }
 
-func (d *Driver) countRows(ctx context.Context, queryID string) (int64, error) {
+func (d *Driver) readRows(ctx context.Context, queryID string, collect func(athenatypes.Row)) (int64, error) {
 	var rows int64
 	input := &awsathena.GetQueryResultsInput{QueryExecutionId: aws.String(queryID), MaxResults: aws.Int32(1000)}
 	firstPage := true
@@ -200,12 +220,24 @@ func (d *Driver) countRows(ctx context.Context, queryID string) (int64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("get Athena query results %s: %w", queryID, err)
 		}
+		if page == nil {
+			return 0, fmt.Errorf("athena returned nil result page")
+		}
 		var pageRows int64
 		if page.ResultSet != nil {
 			pageRows = int64(len(page.ResultSet.Rows))
 		}
 		if firstPage && pageRows > 0 {
 			pageRows-- // Athena returns the column header as the first result row.
+		}
+		if collect != nil && page.ResultSet != nil {
+			start := 0
+			if firstPage && len(page.ResultSet.Rows) > 0 {
+				start = 1
+			}
+			for _, row := range page.ResultSet.Rows[start:] {
+				collect(row)
+			}
 		}
 		rows += pageRows
 		firstPage = false

--- a/tests/perf/drivers/athena/driver_test.go
+++ b/tests/perf/drivers/athena/driver_test.go
@@ -256,3 +256,24 @@ func (f *fakeClient) StopQueryExecution(ctx context.Context, input *awsathena.St
 	f.stopContextErr = ctx.Err()
 	return &awsathena.StopQueryExecutionOutput{}, nil
 }
+
+func TestReadResultsPreservesValuesNullsAndPagination(t *testing.T) {
+	client := &fakeClient{executions: []*athenatypes.QueryExecution{terminalExecution(athenatypes.QueryExecutionStateSucceeded)}, resultPages: []*awsathena.GetQueryResultsOutput{
+		{ResultSet: &athenatypes.ResultSet{Rows: []athenatypes.Row{
+			{Data: []athenatypes.Datum{{VarCharValue: aws.String("key")}, {VarCharValue: aws.String("count")}}},
+			{Data: []athenatypes.Datum{{VarCharValue: aws.String("null")}, {VarCharValue: aws.String("2")}}},
+		}}, NextToken: aws.String("page-2")},
+		{ResultSet: &athenatypes.ResultSet{Rows: []athenatypes.Row{{Data: []athenatypes.Datum{{}, {VarCharValue: aws.String("1")}}}}}},
+	}}
+	got, err := testDriver(t, client).ReadResults(context.Background(), perfcore.Query{Representation: "json", PGWireSQL: "SELECT json_extract_string(properties, '$.browser'), count(*)"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := [][]*string{{aws.String("null"), aws.String("2")}, {nil, aws.String("1")}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("results=%v", got)
+	}
+	if !strings.Contains(aws.ToString(client.startInput.QueryString), "json_extract_scalar") {
+		t.Fatal("incorrect dialect")
+	}
+}

--- a/tests/perf/drivers/pgwire/driver.go
+++ b/tests/perf/drivers/pgwire/driver.go
@@ -68,7 +68,10 @@ func (d *Driver) Execute(ctx context.Context, query core.Query, args []any) (cor
 	if d.exec == nil {
 		return core.ExecutionResult{}, fmt.Errorf("pgwire driver has no executor")
 	}
-	sqlText := query.CanonicalSQL()
+	sqlText, err := query.SQLFor(d.Protocol())
+	if err != nil {
+		return core.ExecutionResult{}, err
+	}
 	if sqlText == "" {
 		return core.ExecutionResult{}, fmt.Errorf("query %s missing pgwire_sql", query.QueryID)
 	}
@@ -174,4 +177,34 @@ func (e *sqlExecutor) Close() error {
 		}
 	}
 	return errors.Join(connErr, e.db.Close())
+}
+
+func (d *Driver) ReadResults(ctx context.Context, query core.Query, args []any) ([][]*string, error) {
+	reader, ok := d.exec.(interface {
+		ReadResults(context.Context, string, []any) ([][]*string, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf("executor cannot read result values")
+	}
+	if d.prepare != nil {
+		if err := d.prepare(ctx); err != nil {
+			return nil, err
+		}
+	}
+	sqlText, err := query.SQLFor(d.Protocol())
+	if err != nil {
+		return nil, err
+	}
+	return reader.ReadResults(ctx, sqlText, args)
+}
+func (e *sqlExecutor) ReadResults(ctx context.Context, query string, args []any) ([][]*string, error) {
+	queryContext := e.db.QueryContext
+	if e.conn != nil {
+		queryContext = e.conn.QueryContext
+	}
+	rows, err := queryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return core.ReadSQLResults(rows)
 }

--- a/tests/perf/drivers/pgwire/driver_test.go
+++ b/tests/perf/drivers/pgwire/driver_test.go
@@ -223,3 +223,22 @@ func (r *cacheTestRows) Next(values []driver.Value) error {
 	values[0] = int64(1)
 	return nil
 }
+
+func TestReadResultsUsesPinnedConnectionAndCollectsValues(t *testing.T) {
+	connector := &cacheTestConnector{}
+	d, err := NewWithDBAndProtocol(sql.OpenDB(connector), core.ProtocolPGWireUncached)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	got, err := d.ReadResults(context.Background(), core.Query{PGWireSQL: "SELECT 1", Representation: "json"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || len(got[0]) != 1 || got[0][0] == nil || *got[0][0] != "1" {
+		t.Fatalf("results=%v", got)
+	}
+	if connector.connections != 1 || len(connector.statements) != 4 {
+		t.Fatalf("setup/connection not preserved: %+v", connector)
+	}
+}

--- a/tests/perf/drivers/trino/driver.go
+++ b/tests/perf/drivers/trino/driver.go
@@ -140,7 +140,10 @@ func (d *Driver) Execute(ctx context.Context, query core.Query, args []any) (cor
 	if d.exec == nil {
 		return core.ExecutionResult{}, fmt.Errorf("trino driver has no executor")
 	}
-	sqlText := query.CanonicalSQL()
+	sqlText, err := query.SQLFor(d.Protocol())
+	if err != nil {
+		return core.ExecutionResult{}, err
+	}
 	if sqlText == "" {
 		return core.ExecutionResult{}, fmt.Errorf("query %s missing canonical SQL", query.QueryID)
 	}
@@ -252,3 +255,25 @@ func (e *sqlExecutor) Close() error {
 
 var _ core.ProtocolDriver = (*Driver)(nil)
 var _ Executor = (*sqlExecutor)(nil)
+
+func (d *Driver) ReadResults(ctx context.Context, query core.Query, args []any) ([][]*string, error) {
+	reader, ok := d.exec.(interface {
+		ReadResults(context.Context, string, []any) ([][]*string, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf("executor cannot read result values")
+	}
+	sqlText, err := query.SQLFor(d.Protocol())
+	if err != nil {
+		return nil, err
+	}
+	return reader.ReadResults(ctx, sqlText, args)
+}
+func (e *sqlExecutor) ReadResults(ctx context.Context, query string, args []any) ([][]*string, error) {
+	queryContext := e.db.QueryContext
+	rows, err := queryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return core.ReadSQLResults(rows)
+}

--- a/tests/perf/drivers/trino/driver_test.go
+++ b/tests/perf/drivers/trino/driver_test.go
@@ -155,3 +155,33 @@ func TestCachedProtocolAndInvalidProtocol(t *testing.T) {
 		t.Fatalf("New invalid protocol error = %v", err)
 	}
 }
+
+type resultExecutor struct {
+	fakeExecutor
+	resultQuery string
+}
+
+func (f *resultExecutor) ReadResults(_ context.Context, query string, _ []any) ([][]*string, error) {
+	f.resultQuery = query
+	value := "Chrome"
+	count := "10"
+	return [][]*string{{&value, &count}}, nil
+}
+func TestReadResultsUsesSameDialectAsExecute(t *testing.T) {
+	exec := &resultExecutor{}
+	d := NewWithExecutor(exec)
+	q := core.Query{Representation: "json", PGWireSQL: "SELECT json_extract_string(properties, '$.browser'), count(*)"}
+	got, err := d.ReadResults(context.Background(), q, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Execute(context.Background(), q, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || *got[0][0] != "Chrome" || *got[0][1] != "10" {
+		t.Fatal(got)
+	}
+	if len(exec.queries) != 1 || exec.resultQuery != exec.queries[0] || !strings.Contains(exec.resultQuery, "json_extract_scalar") {
+		t.Fatalf("SQL differs: %q vs %v", exec.resultQuery, exec.queries)
+	}
+}

--- a/tests/perf/properties/catalog.go
+++ b/tests/perf/properties/catalog.go
@@ -1,0 +1,37 @@
+package properties
+
+import (
+	"fmt"
+	"github.com/posthog/duckgres/tests/perf/core"
+)
+
+// Catalog compares the same immutable day using each reader-supported representation.
+// The fixed IDs describe the workload; the manifest digest identifies its dataset.
+func Catalog(m *Manifest) core.Catalog {
+	targets := []core.Protocol{core.ProtocolPGWireUncached, core.ProtocolPGWireCached, core.ProtocolTrino, core.ProtocolAthena}
+	c := core.Catalog{Name: "properties-perf-v1", Description: "Browser properties on one validated immutable day", DatasetScale: 1, WarmupIterations: 1, MeasureIterations: 4, Targets: targets}
+	bounds := fmt.Sprintf("timestamp >= CAST('%s' AS TIMESTAMP WITH TIME ZONE) AND timestamp < CAST('%s' AS TIMESTAMP WITH TIME ZONE)", m.Start.UTC().Format("2006-01-02 15:04:05 UTC"), m.End.UTC().Format("2006-01-02 15:04:05 UTC"))
+	for _, intent := range []string{"browser_breakdown", "chrome_events"} {
+		for _, rep := range []string{"json", "struct", "variant"} {
+			relation := `"properties_perf"."events_supported"`
+			expr := `json_extract_string(properties, '$."$browser"')`
+			qt := targets
+			switch rep {
+			case "struct":
+				expr = `properties_typed."$browser"`
+			case "variant":
+				expr = `CAST(properties_variant."$browser" AS VARCHAR)`
+				relation = `"properties_perf"."events_variant"`
+				qt = targets[:2]
+			}
+			var sql string
+			if intent == "browser_breakdown" {
+				sql = fmt.Sprintf("SELECT %s AS browser, COUNT(*) AS event_count FROM %s WHERE %s AND %s IS NOT NULL GROUP BY 1 ORDER BY event_count DESC, browser ASC LIMIT 20", expr, relation, bounds, expr)
+			} else {
+				sql = fmt.Sprintf("SELECT event, COUNT(*) AS event_count FROM %s WHERE %s AND %s = 'Chrome' GROUP BY event ORDER BY event_count DESC, event ASC NULLS LAST LIMIT 20", relation, bounds, expr)
+			}
+			c.Queries = append(c.Queries, core.Query{QueryID: "properties_" + intent + "_v1__" + rep, IntentID: "properties." + intent + ".v1", Representation: rep, Targets: qt, PGWireSQL: sql})
+		}
+	}
+	return c
+}

--- a/tests/perf/properties/catalog_test.go
+++ b/tests/perf/properties/catalog_test.go
@@ -1,0 +1,43 @@
+package properties
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/posthog/duckgres/tests/perf/core"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCatalogUsesManifestBoundsAndEquivalentIntents(t *testing.T) {
+	m := &Manifest{Start: time.Date(2026, 3, 17, 0, 0, 0, 0, time.UTC), End: time.Date(2026, 3, 18, 0, 0, 0, 0, time.UTC)}
+	c := Catalog(m)
+	if len(c.Queries) != 6 {
+		t.Fatalf("queries: %d", len(c.Queries))
+	}
+	seen := map[string]bool{}
+	for _, q := range c.Queries {
+		if seen[q.QueryID] {
+			t.Fatalf("duplicate ID %s", q.QueryID)
+		}
+		seen[q.QueryID] = true
+		for _, want := range []string{"2026-03-17 00:00:00 UTC", "2026-03-18 00:00:00 UTC", "LIMIT 20", "ORDER BY"} {
+			if !strings.Contains(q.PGWireSQL, want) {
+				t.Errorf("%s missing %s", q.QueryID, want)
+			}
+		}
+		if q.Representation == "variant" && len(q.Targets) != 2 {
+			t.Fatal("variant must route only to two pgwire modes")
+		}
+		if strings.Contains(q.IntentID, "chrome") && !strings.Contains(q.PGWireSQL, "= 'Chrome'") {
+			t.Fatal("missing exact Chrome filter")
+		}
+	}
+	raw, err := yaml.Marshal(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = core.ParseCatalog(raw); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tests/perf/properties/manifest.go
+++ b/tests/perf/properties/manifest.go
@@ -1,0 +1,213 @@
+// Package properties validates immutable derived-property fixtures before registration.
+package properties
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var requiredChecks = []string{"source_browser_types_all_rows", "original_schema", "original_values_sampled", "derived_values_sampled", "physical_shredding_every_file", "whole_day_row_count", "output_date_bounds", "source_inventory_unchanged"}
+var etagPattern = regexp.MustCompile(`^"[a-fA-F0-9]{32}(-[1-9][0-9]*)?"$`)
+
+// File identifies an immutable object in the published inventory.
+type File struct {
+	Key  string `json:"key"`
+	Size int64  `json:"size"`
+	ETag string `json:"etag"`
+}
+
+// Manifest retains the checked selection and its provenance digest.
+type Manifest struct {
+	FormatVersion int    `json:"format_version"`
+	Status        string `json:"status"`
+	CompletedAt   string `json:"completed_at"`
+	Config        struct {
+		DestinationPrefix string `json:"destination_prefix"`
+		Start             string `json:"start"`
+		End               string `json:"end"`
+	} `json:"config"`
+	Coverage struct {
+		Rows            int64            `json:"rows"`
+		BrowserTypes    map[string]int64 `json:"browser_types"`
+		BrowserNullRows int64            `json:"browser_null_rows"`
+		ChromeRows      int64            `json:"chrome_rows"`
+	} `json:"coverage"`
+	Schema     [][]string `json:"schema"`
+	Checks     []string   `json:"checks"`
+	Validation struct {
+		Mode         string `json:"mode"`
+		SampledFiles int64  `json:"sampled_files"`
+		SampledRows  int64  `json:"sampled_rows"`
+	} `json:"validation"`
+	Writer struct {
+		Shredding  string `json:"shredding"`
+		DuckDB     string `json:"duckdb"`
+		CoreCommit string `json:"core_commit"`
+		CorePatch  string `json:"core_patch_sha256"`
+	} `json:"writer"`
+	Files  []File    `json:"outputs"`
+	Start  time.Time `json:"-"`
+	End    time.Time `json:"-"`
+	Rows   int64     `json:"-"`
+	SHA256 string    `json:"-"`
+}
+
+func Load(name string) (*Manifest, error) {
+	data, err := os.ReadFile(name)
+	if err != nil {
+		return nil, err
+	}
+	return Parse(data)
+}
+func Parse(data []byte) (*Manifest, error) {
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("decode fixture manifest: %w", err)
+	}
+	if err := m.validate(); err != nil {
+		return nil, err
+	}
+	digest := sha256.Sum256(data)
+	m.SHA256 = hex.EncodeToString(digest[:])
+	m.Rows = m.Coverage.Rows
+	return &m, nil
+}
+func (m *Manifest) validate() error {
+	fail := func(s string) error { return fmt.Errorf("invalid properties fixture: %s", s) }
+	if m.FormatVersion != 3 || m.Status != "complete" {
+		return fail("requires complete format version 3")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, m.CompletedAt); err != nil {
+		return fail("completion timestamp")
+	}
+	var err error
+	m.Start, err = time.Parse(time.RFC3339, m.Config.Start)
+	if err != nil {
+		return fail("start timestamp")
+	}
+	m.End, err = time.Parse(time.RFC3339, m.Config.End)
+	if err != nil {
+		return fail("end timestamp")
+	}
+	_, offset := m.Start.Zone()
+	_, endOffset := m.End.Zone()
+	if offset != 0 || endOffset != 0 || m.Start.Hour() != 0 || m.Start.Minute() != 0 || m.Start.Second() != 0 || m.Start.Nanosecond() != 0 || m.End.Sub(m.Start) != 24*time.Hour {
+		return fail("requires exactly one UTC day")
+	}
+	for _, check := range requiredChecks {
+		found := false
+		for _, got := range m.Checks {
+			found = found || check == got
+		}
+		if !found {
+			return fail("missing validation check " + check)
+		}
+	}
+	if m.Validation.Mode != "sampled_values" || m.Validation.SampledFiles <= 0 || m.Validation.SampledFiles > int64(len(m.Files)) || m.Validation.SampledRows <= 0 || m.Validation.SampledRows > m.Coverage.Rows {
+		return fail("sampled validation coverage")
+	}
+	total := int64(0)
+	for kind, n := range m.Coverage.BrowserTypes {
+		if (kind != "MISSING" && kind != "NULL" && kind != "VARCHAR") || n < 0 || n > m.Coverage.Rows-total {
+			return fail("browser type coverage")
+		}
+		total += n
+	}
+	if total != m.Coverage.Rows || total <= 0 || m.Coverage.BrowserNullRows != m.Coverage.BrowserTypes["MISSING"]+m.Coverage.BrowserTypes["NULL"] || m.Coverage.ChromeRows < 0 || m.Coverage.ChromeRows > m.Coverage.BrowserTypes["VARCHAR"] {
+		return fail("row coverage")
+	}
+	fields := map[string]string{}
+	for _, field := range m.Schema {
+		if len(field) != 2 || field[0] == "" || fields[field[0]] != "" {
+			return fail("original schema")
+		}
+		fields[field[0]] = field[1]
+	}
+	if fields["event"] != "VARCHAR" || fields["properties"] != "VARCHAR" || fields["timestamp"] != "TIMESTAMP WITH TIME ZONE" {
+		return fail("original schema required columns")
+	}
+	if m.Writer.Shredding != `STRUCT("$browser" VARCHAR)` || m.Writer.DuckDB == "" || !validHex(m.Writer.CoreCommit, 40) || !validHex(m.Writer.CorePatch, 64) {
+		return fail("writer provenance and shredding")
+	}
+	u, err := s3URL(m.Config.DestinationPrefix)
+	if err != nil || !strings.HasSuffix(m.Config.DestinationPrefix, "/") {
+		return fail("destination prefix")
+	}
+	prefix := strings.TrimPrefix(u.Path, "/") + "data/"
+	seen := map[string]bool{}
+	if len(m.Files) == 0 {
+		return fail("empty inventory")
+	}
+	for _, f := range m.Files {
+		if !strings.HasPrefix(f.Key, prefix) || path.Clean(f.Key) != f.Key || strings.ContainsAny(f.Key, "\x00\r\n*?[]#%") || !strings.HasSuffix(f.Key, ".parquet") || f.Size <= 0 || !etagPattern.MatchString(f.ETag) || seen[f.Key] {
+			return fail("output inventory")
+		}
+		seen[f.Key] = true
+	}
+	return nil
+}
+func validHex(value string, length int) bool {
+	_, err := hex.DecodeString(value)
+	return len(value) == length && err == nil
+}
+func s3URL(value string) (*url.URL, error) {
+	u, err := url.Parse(value)
+	if err != nil || u.Scheme != "s3" || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.RawPath != "" || u.Path == "" {
+		return nil, fmt.Errorf("expected plain s3://bucket/key URI")
+	}
+	return u, nil
+}
+func literal(value string) string { return "'" + strings.ReplaceAll(value, "'", "''") + "'" }
+
+// SetupSQL registers both logical projections from exactly the same objects.
+func (m *Manifest) SetupSQL() string {
+	u, _ := s3URL(m.Config.DestinationPrefix)
+	files := make([]string, len(m.Files))
+	for i, f := range m.Files {
+		files[i] = literal("s3://" + u.Host + "/" + f.Key)
+	}
+	var b strings.Builder
+	b.WriteString("CREATE SCHEMA IF NOT EXISTS properties_perf;\nBEGIN TRANSACTION;\n")
+	for _, table := range []string{"events_supported", "events_variant"} {
+		extra := ""
+		if table == "events_variant" {
+			extra = ", properties_variant VARIANT"
+		}
+		fmt.Fprintf(&b, "DROP TABLE IF EXISTS properties_perf.%s;\nCREATE TABLE properties_perf.%s (event VARCHAR, timestamp TIMESTAMPTZ, properties VARCHAR, properties_typed STRUCT(\"$browser\" VARCHAR)%s);\n", table, table, extra)
+		fmt.Fprintf(&b, "CALL ducklake_add_data_files('ducklake', '%s', [%s], schema => 'properties_perf', ignore_extra_columns => true);\n", table, strings.Join(files, ", "))
+	}
+	b.WriteString("COMMIT;\n")
+	b.WriteString(m.ValidationSQL())
+	return b.String()
+}
+
+// ValidationSQL performs whole-fixture checks outside timed query execution.
+func (m *Manifest) ValidationSQL() string {
+	var b strings.Builder
+	for _, table := range []string{"events_supported", "events_variant"} {
+		fmt.Fprintf(&b, `SELECT CASE WHEN count(*) = %d
+ AND count(*) FILTER (WHERE timestamp IS NULL OR timestamp < TIMESTAMPTZ %s OR timestamp >= TIMESTAMPTZ %s) = 0
+ AND count(*) FILTER (WHERE coalesce(json_type(properties, '$."$browser"'), 'MISSING') NOT IN ('MISSING','NULL','VARCHAR')) = 0
+ AND count(*) FILTER (WHERE coalesce(json_type(properties, '$."$browser"'), 'MISSING') IN ('MISSING','NULL')) = %d
+ AND count(*) FILTER (WHERE json_extract_string(properties, '$."$browser"') = 'Chrome') = %d
+ THEN true ELSE error('properties fixture coverage mismatch') END FROM properties_perf.%s;
+`, m.Rows, literal(m.Config.Start), literal(m.Config.End), m.Coverage.BrowserNullRows, m.Coverage.ChromeRows, table)
+	}
+	return b.String()
+}
+
+// AthenaSQL uses only supported logical fields. Verify the exact prefix inventory first.
+func (m *Manifest) AthenaSQL(table string) (string, error) {
+	if !regexp.MustCompile(`^[a-z][a-z0-9_]*$`).MatchString(table) {
+		return "", fmt.Errorf("athena table must be a lowercase SQL identifier")
+	}
+	return fmt.Sprintf("CREATE EXTERNAL TABLE %s (event string, `timestamp` timestamp, properties string, properties_typed struct<`$browser`:string>) STORED AS PARQUET LOCATION %s;\n", table, literal(m.Config.DestinationPrefix+"data/")), nil
+}

--- a/tests/perf/properties/manifest_test.go
+++ b/tests/perf/properties/manifest_test.go
@@ -1,0 +1,65 @@
+package properties
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func validManifest() map[string]any {
+	return map[string]any{
+		"format_version": 3, "status": "complete", "completed_at": "2026-04-02T00:00:00Z",
+		"config":     map[string]any{"destination_prefix": "s3://example-fixture/derived/day/", "start": "2026-04-01T00:00:00Z", "end": "2026-04-02T00:00:00Z"},
+		"coverage":   map[string]any{"rows": 3, "browser_types": map[string]int64{"VARCHAR": 2, "MISSING": 1}, "browser_null_rows": 1, "chrome_rows": 1},
+		"schema":     [][]string{{"event", "VARCHAR"}, {"timestamp", "TIMESTAMP WITH TIME ZONE"}, {"properties", "VARCHAR"}},
+		"checks":     requiredChecks,
+		"validation": map[string]any{"mode": "sampled_values", "sampled_files": 1, "sampled_rows": 3},
+		"writer":     map[string]any{"shredding": "STRUCT(\"$browser\" VARCHAR)", "duckdb": "1.5.5", "core_commit": strings.Repeat("a", 40), "core_patch_sha256": strings.Repeat("b", 64)},
+		"outputs":    []File{{Key: "derived/day/data/part-000000.parquet", Size: 123, ETag: `"0123456789abcdef0123456789abcdef"`}},
+	}
+}
+
+func TestManifestContract(t *testing.T) {
+	cases := map[string]func(map[string]any){
+		"incomplete": func(m map[string]any) { m["status"] = "running" },
+		"checks":     func(m map[string]any) { m["checks"] = []string{"whole_day_row_count"} },
+		"types": func(m map[string]any) {
+			m["coverage"].(map[string]any)["browser_types"] = map[string]int64{"BIGINT": 3}
+		},
+		"count":     func(m map[string]any) { m["coverage"].(map[string]any)["rows"] = 4 },
+		"date":      func(m map[string]any) { m["config"].(map[string]any)["end"] = "2026-04-03T00:00:00Z" },
+		"schema":    func(m map[string]any) { m["schema"] = [][]string{{"properties", "JSON"}} },
+		"shredding": func(m map[string]any) { m["writer"].(map[string]any)["shredding"] = "" },
+		"outside": func(m map[string]any) {
+			m["outputs"] = []File{{Key: "elsewhere/file.parquet", Size: 12, ETag: `"0123456789abcdef0123456789abcdef"`}}
+		},
+		"etag":       func(m map[string]any) { m["outputs"].([]File)[0].ETag = "" },
+		"wildcard":   func(m map[string]any) { m["outputs"].([]File)[0].Key = "derived/day/data/part-*.parquet" },
+		"provenance": func(m map[string]any) { m["writer"].(map[string]any)["core_patch_sha256"] = strings.Repeat("z", 64) },
+		"duplicate":  func(m map[string]any) { f := m["outputs"].([]File)[0]; m["outputs"] = []File{f, f} },
+	}
+	for name, change := range cases {
+		t.Run(name, func(t *testing.T) {
+			m := validManifest()
+			change(m)
+			data, _ := json.Marshal(m)
+			if _, err := Parse(data); err == nil {
+				t.Fatal("accepted invalid manifest")
+			}
+		})
+	}
+	data, _ := json.Marshal(validManifest())
+	m, err := Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql := m.SetupSQL()
+	for _, want := range []string{"properties_perf.events_supported", "properties_perf.events_variant", "ignore_extra_columns => true", "part-000000.parquet", "error(", "Chrome"} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("missing %s", want)
+		}
+	}
+	if strings.Contains(sql, "*.parquet") {
+		t.Fatal("registration must use exact inventory")
+	}
+}

--- a/tests/perf/properties/remote.go
+++ b/tests/perf/properties/remote.go
@@ -1,0 +1,108 @@
+package properties
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type S3Client interface {
+	GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	ListObjectsV2(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+}
+
+// LoadS3 retrieves a completion manifest; inventory verification remains mandatory.
+func LoadS3(ctx context.Context, client S3Client, uri string) (*Manifest, error) {
+	u, err := s3URL(uri)
+	if err != nil {
+		return nil, err
+	}
+	out, err := client.GetObject(ctx, &s3.GetObjectInput{Bucket: aws.String(u.Host), Key: aws.String(strings.TrimPrefix(u.Path, "/"))})
+	if err != nil {
+		return nil, fmt.Errorf("read completion manifest: %w", err)
+	}
+	defer func() { _ = out.Body.Close() }()
+	data, err := io.ReadAll(io.LimitReader(out.Body, 16<<20))
+	if err != nil {
+		return nil, err
+	}
+	return Parse(data)
+}
+
+// VerifyInventory compares every live data-prefix object, including unexpected files.
+func (m *Manifest) VerifyInventory(ctx context.Context, client S3Client) error {
+	u, _ := s3URL(m.Config.DestinationPrefix)
+	expected := make(map[string]File, len(m.Files))
+	for _, f := range m.Files {
+		expected[f.Key] = f
+	}
+	pager := s3.NewListObjectsV2Paginator(client, &s3.ListObjectsV2Input{Bucket: aws.String(u.Host), Prefix: aws.String(strings.TrimPrefix(u.Path, "/") + "data/")})
+	for pager.HasMorePages() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("verify fixture inventory: %w", err)
+		}
+		for _, object := range page.Contents {
+			key := aws.ToString(object.Key)
+			f, ok := expected[key]
+			if !ok || f.Size != aws.ToInt64(object.Size) || f.ETag != aws.ToString(object.ETag) {
+				return fmt.Errorf("fixture inventory changed: unexpected or modified object")
+			}
+			delete(expected, key)
+		}
+	}
+	if len(expected) > 0 {
+		return fmt.Errorf("fixture inventory changed: %d missing objects", len(expected))
+	}
+	return nil
+}
+
+type GlueClient interface {
+	GetTable(context.Context, *glue.GetTableInput, ...func(*glue.Options)) (*glue.GetTableOutput, error)
+}
+
+// VerifyAthenaTable checks the preprovisioned logical projection without mutating Glue.
+func (m *Manifest) VerifyAthenaTable(ctx context.Context, client GlueClient, database, table string) error {
+	out, err := client.GetTable(ctx, &glue.GetTableInput{DatabaseName: aws.String(database), Name: aws.String(table)})
+	if err != nil {
+		return fmt.Errorf("verify Athena table: %w", err)
+	}
+	if out.Table == nil || out.Table.StorageDescriptor == nil {
+		return fmt.Errorf("athena table lacks storage descriptor")
+	}
+	sd := out.Table.StorageDescriptor
+	if strings.EqualFold(out.Table.Parameters["projection.enabled"], "true") {
+		return fmt.Errorf("athena partition projection must be disabled")
+	}
+	if sd.SerdeInfo == nil || aws.ToString(sd.SerdeInfo.SerializationLibrary) != "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe" {
+		return fmt.Errorf("athena table requires standard Parquet SerDe")
+	}
+
+	if aws.ToString(sd.Location) != m.Config.DestinationPrefix+"data/" {
+		return fmt.Errorf("athena table location differs from fixture")
+	}
+	if strings.EqualFold(out.Table.Parameters["parquet.column.index.access"], "true") || strings.EqualFold(sd.SerdeInfo.Parameters["parquet.column.index.access"], "true") {
+		return fmt.Errorf("athena table must read Parquet columns by name")
+	}
+	required := map[string]string{"event": "string", "timestamp": "timestamp", "properties": "string", "properties_typed": "struct<$browser:string>"}
+	if len(sd.Columns) != len(required) || len(out.Table.PartitionKeys) != 0 {
+		return fmt.Errorf("athena table must expose exactly the supported unpartitioned columns")
+	}
+	for _, c := range sd.Columns {
+		name := aws.ToString(c.Name)
+		typ := strings.ReplaceAll(strings.ToLower(aws.ToString(c.Type)), "`", "")
+		if required[name] != typ || typ == "" {
+			return fmt.Errorf("athena table logical column mismatch")
+		}
+		delete(required, name)
+	}
+	if len(required) != 0 || aws.ToString(sd.InputFormat) != "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat" || aws.ToString(sd.OutputFormat) != "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat" {
+		return fmt.Errorf("athena table must use the supported Parquet schema")
+	}
+	return nil
+}

--- a/tests/perf/properties/remote_test.go
+++ b/tests/perf/properties/remote_test.go
@@ -1,0 +1,121 @@
+package properties
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	glueTypes "github.com/aws/aws-sdk-go-v2/service/glue/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+type fakeS3 struct {
+	pages []*s3.ListObjectsV2Output
+	calls int
+}
+
+func (f *fakeS3) GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	panic("unused")
+}
+func (f *fakeS3) ListObjectsV2(_ context.Context, in *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	out := f.pages[f.calls]
+	f.calls++
+	return out, nil
+}
+func TestVerifyInventory(t *testing.T) {
+	raw := validManifest()
+	f := raw["outputs"].([]File)[0]
+	second := f
+	second.Key = "derived/day/data/part-000001.parquet"
+	raw["outputs"] = []File{f, second}
+	data, _ := json.Marshal(raw)
+	m, err := Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj := func(f File) types.Object {
+		return types.Object{Key: aws.String(f.Key), Size: aws.Int64(f.Size), ETag: aws.String(f.ETag)}
+	}
+	for _, mode := range []string{"valid", "extra", "size", "etag", "missing"} {
+		t.Run(mode, func(t *testing.T) {
+			a, b := obj(f), obj(second)
+			if mode == "size" {
+				b.Size = aws.Int64(1)
+			}
+			if mode == "etag" {
+				b.ETag = aws.String("changed")
+			}
+			if mode == "extra" {
+				b.Key = aws.String("derived/day/data/unexpected.parquet")
+			}
+			items := []types.Object{b}
+			if mode == "missing" {
+				items = nil
+			}
+			client := &fakeS3{pages: []*s3.ListObjectsV2Output{{Contents: []types.Object{a}, IsTruncated: aws.Bool(true), NextContinuationToken: aws.String("next")}, {Contents: items}}}
+			err := m.VerifyInventory(context.Background(), client)
+			if (err == nil) != (mode == "valid") {
+				t.Fatalf("mode=%s err=%v", mode, err)
+			}
+			if client.calls != 2 {
+				t.Fatal("pagination not consumed")
+			}
+		})
+	}
+}
+
+type fakeGlue struct{ table *glueTypes.Table }
+
+func (f fakeGlue) GetTable(context.Context, *glue.GetTableInput, ...func(*glue.Options)) (*glue.GetTableOutput, error) {
+	return &glue.GetTableOutput{Table: f.table}, nil
+}
+func TestVerifyAthenaTable(t *testing.T) {
+	data, _ := json.Marshal(validManifest())
+	m, err := Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mode := range []string{"valid", "location", "variant", "format", "serde", "projection", "index_table", "index_serde", "custom_input", "custom_output"} {
+		t.Run(mode, func(t *testing.T) {
+			sd := &glueTypes.StorageDescriptor{SerdeInfo: &glueTypes.SerDeInfo{SerializationLibrary: aws.String("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe")}, Location: aws.String(m.Config.DestinationPrefix + "data/"), InputFormat: aws.String("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"), OutputFormat: aws.String("org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat")}
+			for n, typ := range map[string]string{"event": "string", "timestamp": "timestamp", "properties": "string", "properties_typed": "struct<`$browser`:string>"} {
+				sd.Columns = append(sd.Columns, glueTypes.Column{Name: aws.String(n), Type: aws.String(typ)})
+			}
+			if mode == "location" {
+				sd.Location = aws.String("s3://example-fixture/other/")
+			}
+			if mode == "variant" {
+				sd.Columns = append(sd.Columns, glueTypes.Column{Name: aws.String("properties_variant"), Type: aws.String("variant")})
+			}
+			if mode == "format" {
+				sd.InputFormat = aws.String("text")
+			}
+			table := &glueTypes.Table{StorageDescriptor: sd}
+			if mode == "serde" {
+				sd.SerdeInfo.SerializationLibrary = aws.String("custom")
+			}
+			if mode == "projection" {
+				table.Parameters = map[string]string{"projection.enabled": "true"}
+			}
+			if mode == "index_table" {
+				table.Parameters = map[string]string{"parquet.column.index.access": "true"}
+			}
+			if mode == "index_serde" {
+				sd.SerdeInfo.Parameters = map[string]string{"parquet.column.index.access": "true"}
+			}
+			if mode == "custom_input" {
+				sd.InputFormat = aws.String("custom.parquet.InputFormat")
+			}
+			if mode == "custom_output" {
+				sd.OutputFormat = aws.String("custom.parquet.OutputFormat")
+			}
+			err := m.VerifyAthenaTable(context.Background(), fakeGlue{table}, "example", "properties_events_supported")
+			if (err == nil) != (mode == "valid") {
+				t.Fatalf("mode %s err %v", mode, err)
+			}
+		})
+	}
+}

--- a/tests/perf/properties/semantics_integration_test.go
+++ b/tests/perf/properties/semantics_integration_test.go
@@ -1,0 +1,137 @@
+package properties
+
+import (
+	"context"
+	"database/sql"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/posthog/duckgres/tests/perf/core"
+)
+
+// This in-memory edge-case corpus exercises the actual workload SQL. It does
+// not write Parquet or replace the separate published-fixture correctness gate.
+func TestCatalogPropertySemantics(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	for _, statement := range []string{
+		`CREATE SCHEMA properties_perf`,
+		`CREATE TABLE properties_perf.events_supported (event VARCHAR, timestamp TIMESTAMPTZ, properties VARCHAR, properties_typed STRUCT("$browser" VARCHAR))`,
+		`INSERT INTO properties_perf.events_supported VALUES
+   ('start', '2026-03-17 00:00:00+00', '{"$browser":"Chrome"}', {'$browser':'Chrome'}),
+   ('start', '2026-03-17 23:59:59.999999+00', '{"$browser":"Chrome"}', {'$browser':'Chrome'}),
+   ('other', '2026-03-17 12:00:00+00', '{"$browser":"chrome"}', {'$browser':'chrome'}),
+   ('other', '2026-03-17 12:00:00+00', '{"$browser":"A\"B\\C"}', {'$browser':'A"B\C'}),
+   ('other', '2026-03-17 12:00:00+00', '{"$browser":"null"}', {'$browser':'null'}),
+   ('other', '2026-03-17 12:00:00+00', '{"$browser":""}', {'$browser':''}),
+   ('missing', '2026-03-17 12:00:00+00', '{}', {'$browser':NULL}),
+   ('jsonnull', '2026-03-17 12:00:00+00', '{"$browser":null}', {'$browser':NULL}),
+   ('sqlnull', '2026-03-17 12:00:00+00', NULL, NULL),
+   ('before', '2026-03-16 23:59:59.999999+00', '{"$browser":"Chrome"}', {'$browser':'Chrome'}),
+   ('after', '2026-03-18 00:00:00+00', '{"$browser":"Chrome"}', {'$browser':'Chrome'})`,
+		`CREATE TABLE properties_perf.events_variant AS SELECT *, CAST(CAST(properties AS JSON) AS VARIANT) AS properties_variant FROM properties_perf.events_supported`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c := Catalog(&Manifest{Start: time.Date(2026, 3, 17, 0, 0, 0, 0, time.UTC), End: time.Date(2026, 3, 18, 0, 0, 0, 0, time.UTC)})
+	for _, zone := range []string{"UTC", "America/Toronto"} {
+		if _, err := db.Exec("SET TimeZone = '" + zone + "'"); err != nil {
+			t.Fatal(err)
+		}
+		for _, q := range c.Queries {
+			t.Run(zone+"/"+q.QueryID, func(t *testing.T) {
+				sqlText, err := q.SQLFor(core.ProtocolPGWire)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rows, err := db.QueryContext(context.Background(), sqlText)
+				if err != nil {
+					t.Fatal(err)
+				}
+				got, err := core.ReadSQLResults(rows)
+				if err != nil {
+					t.Fatal(err)
+				}
+				expected := [][]*string{{semanticsCell("Chrome"), semanticsCell("2")}, {semanticsCell(""), semanticsCell("1")}, {semanticsCell("A\"B\\C"), semanticsCell("1")}, {semanticsCell("chrome"), semanticsCell("1")}, {semanticsCell("null"), semanticsCell("1")}}
+				if strings.Contains(q.IntentID, "chrome") {
+					expected = [][]*string{{semanticsCell("start"), semanticsCell("2")}}
+				}
+				if !reflect.DeepEqual(got, expected) {
+					t.Fatalf("results differ: got %s want %s", semanticsValues(got), semanticsValues(expected))
+				}
+			})
+		}
+	}
+}
+func semanticsCell(s string) *string { return &s }
+func semanticsValues(rows [][]*string) [][]string {
+	result := make([][]string, len(rows))
+	for i, row := range rows {
+		result[i] = make([]string, len(row))
+		for j, cell := range row {
+			if cell == nil {
+				result[i][j] = "<SQL NULL>"
+			} else {
+				result[i][j] = *cell
+			}
+		}
+	}
+	return result
+}
+
+func TestFixtureValidationRejectsIncompatibleBrowserTypes(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	m := &Manifest{Rows: 1}
+	m.Config.Start = "2026-03-17T00:00:00Z"
+	m.Config.End = "2026-03-18T00:00:00Z"
+	if _, err := db.Exec(`CREATE SCHEMA properties_perf`); err != nil {
+		t.Fatal(err)
+	}
+	for _, table := range []string{"events_supported", "events_variant"} {
+		if _, err := db.Exec(`CREATE TABLE properties_perf.` + table + ` (properties VARCHAR, timestamp TIMESTAMPTZ)`); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, tc := range []struct {
+		name, properties string
+		nulls, chrome    int64
+		bad              bool
+	}{
+		{"missing", "{}", 1, 0, false}, {"json null", `{"$browser":null}`, 1, 0, false},
+		{"string", `{"$browser":"Chrome"}`, 0, 1, false}, {"case", `{"$browser":"chrome"}`, 0, 0, false},
+		{"escaped", `{"$browser":"A\"B\\C"}`, 0, 0, false},
+		{"number", `{"$browser":42}`, 0, 0, true}, {"boolean", `{"$browser":true}`, 0, 0, true},
+		{"array", `{"$browser":[]}`, 0, 0, true}, {"object", `{"$browser":{}}`, 0, 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m.Coverage.BrowserNullRows = tc.nulls
+			m.Coverage.ChromeRows = tc.chrome
+			for _, table := range []string{"events_supported", "events_variant"} {
+				if _, err := db.Exec(`DELETE FROM properties_perf.` + table); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := db.Exec(`INSERT INTO properties_perf.`+table+` VALUES (?,TIMESTAMPTZ '2026-03-17 12:00:00+00')`, tc.properties); err != nil {
+					t.Fatal(err)
+				}
+			}
+			_, err := db.Exec(m.ValidationSQL())
+			if (err != nil) != tc.bad {
+				t.Fatalf("validation error=%v, expected rejection=%v", err, tc.bad)
+			}
+		})
+	}
+}

--- a/tests/perf/publisher/publisher.go
+++ b/tests/perf/publisher/publisher.go
@@ -50,6 +50,7 @@ type artifacts struct {
 }
 
 type resultRow struct {
+	Representation   string
 	QueryID          string
 	IntentID         string
 	MeasureIteration int
@@ -184,7 +185,7 @@ func loadQueryResults(path string) ([]resultRow, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read query_results.csv header: %w", err)
 	}
-	if !equalStringSlices(header, expectedQueryResultsHeader) {
+	if !equalStringSlices(header, expectedQueryResultsHeader) && !equalStringSlices(header, append(append([]string(nil), expectedQueryResultsHeader...), "representation")) {
 		return nil, fmt.Errorf("unexpected query_results.csv header: %q", strings.Join(header, ","))
 	}
 	var results []resultRow
@@ -206,7 +207,7 @@ func loadQueryResults(path string) ([]resultRow, error) {
 }
 
 func parseResultRow(record []string) (resultRow, error) {
-	if len(record) != len(expectedQueryResultsHeader) {
+	if len(record) != len(expectedQueryResultsHeader) && len(record) != len(expectedQueryResultsHeader)+1 {
 		return resultRow{}, fmt.Errorf("unexpected query_results.csv column count: got %d want %d", len(record), len(expectedQueryResultsHeader))
 	}
 	measureIteration, err := strconv.Atoi(record[2])
@@ -229,7 +230,15 @@ func parseResultRow(record []string) (resultRow, error) {
 	if err != nil {
 		return resultRow{}, fmt.Errorf("parse started_at %q: %w", record[9], err)
 	}
+	representation := ""
+	if len(record) == len(expectedQueryResultsHeader)+1 {
+		representation = record[len(record)-1]
+		if representation != "" && representation != "json" && representation != "struct" && representation != "variant" {
+			return resultRow{}, fmt.Errorf("invalid representation %q", representation)
+		}
+	}
 	return resultRow{
+		Representation:   representation,
 		QueryID:          record[0],
 		IntentID:         record[1],
 		MeasureIteration: measureIteration,
@@ -276,12 +285,12 @@ func publishArtifacts(ctx context.Context, cfg Config, db dbHandle, loaded artif
 		return fmt.Errorf("insert run summary: %w", err)
 	}
 	insertQuery := fmt.Sprintf(
-		"INSERT INTO %s.query_results (run_id, query_id, intent_id, measure_iteration, protocol, status, error, error_class, rows, duration_ms, started_at, dataset_version, run_date) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
+		"INSERT INTO %s.query_results (run_id, query_id, intent_id, measure_iteration, protocol, status, error, error_class, rows, duration_ms, started_at, dataset_version, run_date, representation) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
 		schema,
 	)
 	runDate := loaded.Summary.StartedAt.UTC().Format("2006-01-02")
 	for _, result := range loaded.Results {
-		if _, err = tx.ExecContext(ctx, insertQuery, loaded.Summary.RunID, result.QueryID, result.IntentID, result.MeasureIteration, result.Protocol, result.Status, result.Error, result.ErrorClass, result.Rows, result.DurationMS, result.StartedAt, loaded.Summary.DatasetVersion, runDate); err != nil {
+		if _, err = tx.ExecContext(ctx, insertQuery, loaded.Summary.RunID, result.QueryID, result.IntentID, result.MeasureIteration, result.Protocol, result.Status, result.Error, result.ErrorClass, result.Rows, result.DurationMS, result.StartedAt, loaded.Summary.DatasetVersion, runDate, result.Representation); err != nil {
 			return fmt.Errorf("insert query result (%s/%s/%d/%s): %w", loaded.Summary.RunID, result.QueryID, result.MeasureIteration, result.Protocol, err)
 		}
 	}
@@ -310,6 +319,7 @@ func bootstrapSchema(ctx context.Context, tx txHandle, schema string) error {
   run_date DATE NOT NULL
 )`, schema),
 		fmt.Sprintf("ALTER TABLE %s.query_results ADD COLUMN IF NOT EXISTS measure_iteration INTEGER", schema),
+		fmt.Sprintf("ALTER TABLE %s.query_results ADD COLUMN IF NOT EXISTS representation TEXT", schema),
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.runs (
   run_id TEXT NOT NULL,
   dataset_version TEXT NOT NULL,

--- a/tests/perf/publisher/publisher_test.go
+++ b/tests/perf/publisher/publisher_test.go
@@ -151,6 +151,7 @@ func TestPublishArtifactsBootstrapsAndReplacesRunData(t *testing.T) {
 		t.Fatalf("loadArtifacts returned error: %v", err)
 	}
 
+	artifacts.Results[0].Representation = "struct"
 	db := &fakeDB{tx: &fakeTx{}}
 	cfg := Config{Schema: "duckgres_perf", BootstrapSchema: true}
 	if err := publishArtifacts(context.Background(), cfg, db, artifacts); err != nil {
@@ -162,24 +163,27 @@ func TestPublishArtifactsBootstrapsAndReplacesRunData(t *testing.T) {
 	if db.tx.rolledBack {
 		t.Fatalf("did not expect rollback")
 	}
-	if len(db.tx.execs) != 9 {
-		t.Fatalf("expected 9 execs, got %d", len(db.tx.execs))
+	if len(db.tx.execs) != 10 {
+		t.Fatalf("expected 10 execs, got %d", len(db.tx.execs))
 	}
-	runInsert := db.tx.execs[6]
+	runInsert := db.tx.execs[7]
 	if !strings.Contains(runInsert.query, "INSERT INTO duckgres_perf.runs") {
 		t.Fatalf("unexpected run insert query: %s", runInsert.query)
 	}
 	if got, ok := runInsert.args[0].(string); !ok || got != "nightly-v1-20260311T234300Z" {
 		t.Fatalf("unexpected run insert args: %#v", runInsert.args)
 	}
-	firstResultInsert := db.tx.execs[7]
+	firstResultInsert := db.tx.execs[8]
 	if !strings.Contains(firstResultInsert.query, "INSERT INTO duckgres_perf.query_results") {
 		t.Fatalf("unexpected result insert query: %s", firstResultInsert.query)
 	}
 	if got, ok := firstResultInsert.args[8].(*int64); !ok || got == nil || *got != 1 {
 		t.Fatalf("expected rows pointer with value 1, got %#v", firstResultInsert.args[8])
 	}
-	secondResultInsert := db.tx.execs[8]
+	if got := firstResultInsert.args[13]; got != "struct" {
+		t.Fatalf("representation not published: %v", got)
+	}
+	secondResultInsert := db.tx.execs[9]
 	if got, ok := secondResultInsert.args[6].(*string); !ok || got == nil || *got != "boom" {
 		t.Fatalf("expected error arg, got %#v", secondResultInsert.args[6])
 	}
@@ -191,11 +195,11 @@ func TestBootstrapSchemaDoesNotUseUnsupportedConstraints(t *testing.T) {
 	if err := bootstrapSchema(context.Background(), tx, "duckgres_perf"); err != nil {
 		t.Fatalf("bootstrapSchema returned error: %v", err)
 	}
-	if len(tx.execs) != 4 {
-		t.Fatalf("expected 4 bootstrap statements, got %d", len(tx.execs))
+	if len(tx.execs) != 5 {
+		t.Fatalf("expected 5 bootstrap statements, got %d", len(tx.execs))
 	}
 
-	runsDDL := tx.execs[3].query
+	runsDDL := tx.execs[4].query
 	if !strings.Contains(runsDDL, "CREATE TABLE IF NOT EXISTS duckgres_perf.runs") {
 		t.Fatalf("unexpected runs ddl: %s", runsDDL)
 	}
@@ -211,7 +215,7 @@ func TestPublishArtifactsRollsBackOnInsertFailure(t *testing.T) {
 		t.Fatalf("loadArtifacts returned error: %v", err)
 	}
 
-	db := &fakeDB{tx: &fakeTx{failOnExec: 7}}
+	db := &fakeDB{tx: &fakeTx{failOnExec: 8}}
 	cfg := Config{Schema: "duckgres_perf", BootstrapSchema: true}
 	err = publishArtifacts(context.Background(), cfg, db, artifacts)
 	if err == nil || !strings.Contains(err.Error(), "insert run summary") {
@@ -345,5 +349,20 @@ func writeMinimalCSVFile(t *testing.T, runDir string) {
 	csvPath := filepath.Join(runDir, "query_results.csv")
 	if err := os.WriteFile(csvPath, []byte(csvText), 0o644); err != nil {
 		t.Fatalf("WriteFile csv: %v", err)
+	}
+}
+
+func TestLoadQueryResultsWithRepresentationColumn(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "query_results.csv")
+	data := "query_id,intent_id,measure_iteration,protocol,status,error,error_class,rows,duration_ms,started_at,representation\nq__struct,i,1,pgwire,ok,,,2,10,2026-03-17T00:00:00Z,struct\n"
+	if err := os.WriteFile(path, []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := loadQueryResults(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows[0].Representation != "struct" {
+		t.Fatalf("lost label: %+v", rows[0])
 	}
 }


### PR DESCRIPTION
Preserve the existing frozen performance corpus, dataset, five targets, and dashboard history. Add an optional properties comparison after the original benchmark results have been written, using a separately generated modest single-day Parquet fixture supplied through `properties_s3_uri`. With no input, the original suite runs alone.

The properties phase compares browser counts and Chrome-filtered event counts across Duckgres vanilla/cache JSON, Trino vanilla JSON, and Athena STRUCT. Cached Trino VARIANT emits explicit unsupported/skipped results without opening a driver or blocking the correctness gate. Supported representations must return identical ordered results before timing.

Properties registration uses a separate Hoglake catalog rooted at the selected fixture. The disposable tenant Trino catalog keeps its identity, credentials, and cache settings while switching its backend mapping after the original benchmarks. Properties results use `perf-properties/` and a distinct run ID; failures cannot prevent completed original results from being uploaded or published. Fixture generation must provision the matching Athena external table; the runner only verifies it. No completion manifest or new repository secret is needed.

Validation: the full isolated scenario completed successfully on revision `2c791199`, including the original corpus, optional properties comparisons, and cleanup: https://github.com/PostHog/duckgres/actions/runs/34972872619. Both benchmark phases produced result artifacts with no query errors; unsupported cached Trino VARIANT comparisons are explicitly skipped. Branch runs do not publish to the shared dashboard. Existing scenario, perf, and deployment fixture checks pass. `just lint` reports only the known SA4023 diagnostics.
